### PR TITLE
Release 2.1.0

### DIFF
--- a/src/IWristbandApiClient.cs
+++ b/src/IWristbandApiClient.cs
@@ -27,9 +27,9 @@ internal interface IWristbandApiClient
     /// Calls the Wristband Token Endpoint with the refresh token grant type to refresh an expired access token.
     /// </summary>
     /// <param name="refreshToken">The refresh token used to obtain a new access token.</param>
-    /// <returns>A <see cref="Task{TokenData}"/> representing the asynchronous operation. The result contains the refreshed access token, id token, and refresh token.</returns>
+    /// <returns>A <see cref="Task{TokenResponse}"/> representing the asynchronous operation. The result contains the refreshed access token, id token, and refresh token.</returns>
     /// <remarks><a href="https://docs.wristband.dev/reference/tokenv1">Wristband Token Endpoint</a></remarks>
-    Task<TokenData> RefreshToken(string refreshToken);
+    Task<TokenResponse> RefreshToken(string refreshToken);
 
     /// <summary>
     /// Calls the Wristband Revoke Token Endpoint to revoke a refresh token.

--- a/src/Wristband.AspNet.Auth.csproj
+++ b/src/Wristband.AspNet.Auth.csproj
@@ -45,7 +45,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/WristbandApiClient.cs
+++ b/src/WristbandApiClient.cs
@@ -155,7 +155,7 @@ internal class WristbandApiClient : IWristbandApiClient
     /// Implements <see cref="IWristbandApiClient.RefreshToken"/>.
     /// </summary>
     /// <inheritdoc />
-    public async Task<TokenData> RefreshToken(string refreshToken)
+    public async Task<TokenResponse> RefreshToken(string refreshToken)
     {
         var formParams = new Dictionary<string, string>
         {
@@ -188,11 +188,13 @@ internal class WristbandApiClient : IWristbandApiClient
 
             var responseContent = await response.Content.ReadAsStringAsync();
             var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(responseContent);
-            return new TokenData(
-                tokenResponse?.AccessToken ?? string.Empty,
-                tokenResponse?.ExpiresIn ?? 0,
-                tokenResponse?.IdToken ?? string.Empty,
-                tokenResponse?.RefreshToken);
+
+            if (tokenResponse == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize token response.");
+            }
+
+            return tokenResponse;
         }
         catch (WristbandError)
         {

--- a/src/types-and-dtos/public/CallbackData.cs
+++ b/src/types-and-dtos/public/CallbackData.cs
@@ -10,6 +10,7 @@ public class CallbackData : TokenData
     /// </summary>
     public static readonly CallbackData Empty = new CallbackData(
         accessToken: "empty",
+        expiresAt: 0,
         expiresIn: 0,
         idToken: "empty",
         refreshToken: null,
@@ -23,7 +24,8 @@ public class CallbackData : TokenData
     /// Initializes a new instance of the <see cref="CallbackData"/> class with the specified data.
     /// </summary>
     /// <param name="accessToken">The access token.</param>
-    /// <param name="expiresIn">The expiration time of the access token (in seconds).</param>
+    /// <param name="expiresAt">The absolute expiration time of the access token in milliseconds since the Unix epoch.</param>
+    /// <param name="expiresIn">The duration from the current time until the access token is expired (in seconds).</param>
     /// <param name="idToken">The ID token.</param>
     /// <param name="refreshToken">The refresh token (optional).</param>
     /// <param name="userinfo">The user information.</param>
@@ -34,6 +36,7 @@ public class CallbackData : TokenData
     /// <exception cref="InvalidOperationException">Thrown if any required field is null, empty, or invalid.</exception>
     public CallbackData(
         string accessToken,
+        long expiresAt,
         int expiresIn,
         string idToken,
         string? refreshToken,
@@ -42,7 +45,7 @@ public class CallbackData : TokenData
         string? tenantCustomDomain,
         Dictionary<string, object>? customState,
         string? returnUrl)
-        : base(accessToken, expiresIn, idToken, refreshToken)
+        : base(accessToken, expiresAt, expiresIn, idToken, refreshToken)
     {
         if (userinfo == null)
         {

--- a/src/types-and-dtos/public/TokenData.cs
+++ b/src/types-and-dtos/public/TokenData.cs
@@ -9,15 +9,21 @@ public class TokenData
     /// Initializes a new instance of the <see cref="TokenData"/> class with the specified token data.
     /// </summary>
     /// <param name="accessToken">The access token.</param>
+    /// <param name="expiresAt">The absolute expiration time of the access token in milliseconds since the Unix epoch.</param>
     /// <param name="expiresIn">The duration from the current time until the access token expires (in seconds).</param>
     /// <param name="idToken">The ID token.</param>
     /// <param name="refreshToken">The refresh token (optional).</param>
     /// <exception cref="InvalidOperationException">Thrown if any required field is null, empty, or invalid.</exception>
-    public TokenData(string accessToken, int expiresIn, string idToken, string? refreshToken)
+    public TokenData(string accessToken, long expiresAt, int expiresIn, string idToken, string? refreshToken)
     {
         if (string.IsNullOrEmpty(accessToken))
         {
             throw new InvalidOperationException("[AccessToken] cannot be null or empty.");
+        }
+
+        if (expiresAt < 0)
+        {
+            throw new InvalidOperationException("[ExpiresAt] must be a non-negative integer.");
         }
 
         if (expiresIn < 0)
@@ -31,6 +37,7 @@ public class TokenData
         }
 
         AccessToken = accessToken;
+        ExpiresAt = expiresAt;
         ExpiresIn = expiresIn;
         IdToken = idToken;
         RefreshToken = refreshToken;
@@ -40,6 +47,11 @@ public class TokenData
     /// Gets the access token.
     /// </summary>
     public string AccessToken { get; }
+
+    /// <summary>
+    /// Gets the absolute expiration time of the access token in milliseconds since the Unix epoch.
+    /// </summary>
+    public long ExpiresAt { get; }
 
     /// <summary>
     /// Gets the expiration time of the access token (in seconds).

--- a/src/types-and-dtos/public/WristbandAuthConfig.cs
+++ b/src/types-and-dtos/public/WristbandAuthConfig.cs
@@ -26,6 +26,7 @@ public class WristbandAuthConfig
     /// <param name="parseTenantFromRootDomain">The root domain for your application.</param>
     /// <param name="scopes">The scopes required for authentication.</param>
     /// <param name="isApplicationCustomDomainActive">Indicates whether an application-level custom domain is active for the Wristband application.</param>
+    /// <param name="tokenExpirationBuffer">Buffer time (in seconds) to subtract from the access token’s expiration time. This causes the token to be treated as expired before its actual expiration, helping to avoid token expiration during API calls.</param>
     public WristbandAuthConfig(
         string? clientId,
         string? clientSecret,
@@ -37,7 +38,8 @@ public class WristbandAuthConfig
         bool? dangerouslyDisableSecureCookies,
         string? parseTenantFromRootDomain,
         List<string>? scopes,
-        bool? isApplicationCustomDomainActive)
+        bool? isApplicationCustomDomainActive,
+        int? tokenExpirationBuffer)
     {
         ClientId = clientId;
         ClientSecret = clientSecret;
@@ -50,6 +52,7 @@ public class WristbandAuthConfig
         ParseTenantFromRootDomain = parseTenantFromRootDomain;
         Scopes = scopes;
         IsApplicationCustomDomainActive = isApplicationCustomDomainActive;
+        TokenExpirationBuffer = tokenExpirationBuffer;
     }
 
     /// <summary>
@@ -71,6 +74,11 @@ public class WristbandAuthConfig
     /// Gets or sets whether to disable the "Secure" cookie attribute. This should only be set to true in local development.
     /// </summary>
     public bool? DangerouslyDisableSecureCookies { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether an application-level custom domain is active for the Wristband application.
+    /// </summary>
+    public bool? IsApplicationCustomDomainActive { get; set; } = false;
 
     /// <summary>
     /// Gets or sets the secret used for encryption and decryption of login state cookies. It should be 32 or more characters long.
@@ -98,9 +106,9 @@ public class WristbandAuthConfig
     public List<string>? Scopes { get; set; } = new List<string>();
 
     /// <summary>
-    /// Gets or sets whether an application-level custom domain is active for the Wristband application.
+    /// Gets or sets the buffer time (in seconds) to subtract from the access token’s expiration time.
     /// </summary>
-    public bool? IsApplicationCustomDomainActive { get; set; } = false;
+    public int? TokenExpirationBuffer { get; set; } = 60;
 
     /// <summary>
     /// Gets or sets the vanity domain of the Wristband application.

--- a/tests/types-and-dtos/public/CallbackDataTests.cs
+++ b/tests/types-and-dtos/public/CallbackDataTests.cs
@@ -7,6 +7,7 @@ namespace Wristband.AspNet.Auth.Tests
         {
             Assert.Throws<InvalidOperationException>(() => new CallbackData(
                 accessToken: "token",
+                expiresAt: DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds(),
                 expiresIn: 3600,
                 idToken: "id_token",
                 refreshToken: "refresh_token",
@@ -21,8 +22,11 @@ namespace Wristband.AspNet.Auth.Tests
         [Fact]
         public void Constructor_NullOrEmptyTenantDomainName_ThrowsInvalidOperationException()
         {
+            var expiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
+
             Assert.Throws<InvalidOperationException>(() => new CallbackData(
                 accessToken: "token",
+                expiresAt: expiresAt,
                 expiresIn: 3600,
                 idToken: "id_token",
                 refreshToken: "refresh_token",
@@ -35,6 +39,7 @@ namespace Wristband.AspNet.Auth.Tests
 
             Assert.Throws<InvalidOperationException>(() => new CallbackData(
                 accessToken: "token",
+                expiresAt: expiresAt,
                 expiresIn: 3600,
                 idToken: "id_token",
                 refreshToken: "refresh_token",
@@ -51,9 +56,11 @@ namespace Wristband.AspNet.Auth.Tests
         {
             var userinfo = new UserInfo("{\"name\":\"John\"}");
             var customState = new Dictionary<string, object> { { "key", "value" } };
+            var expiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
 
             var callbackData = new CallbackData(
                 accessToken: "token",
+                expiresAt: expiresAt,
                 expiresIn: 3600,
                 idToken: "id_token",
                 refreshToken: "refresh_token",
@@ -65,6 +72,7 @@ namespace Wristband.AspNet.Auth.Tests
             );
 
             Assert.Equal("token", callbackData.AccessToken);
+            Assert.Equal(expiresAt, callbackData.ExpiresAt);
             Assert.Equal(3600, callbackData.ExpiresIn);
             Assert.Equal("id_token", callbackData.IdToken);
             Assert.Equal("refresh_token", callbackData.RefreshToken);
@@ -78,8 +86,11 @@ namespace Wristband.AspNet.Auth.Tests
         [Fact]
         public void Constructor_NullOptionalParameters_SetsDefaults()
         {
+            var expiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
+
             var callbackData = new CallbackData(
                 accessToken: "token",
+                expiresAt: expiresAt,
                 expiresIn: 3600,
                 idToken: "id_token",
                 refreshToken: "refresh_token",
@@ -90,6 +101,7 @@ namespace Wristband.AspNet.Auth.Tests
                 returnUrl: null
             );
 
+            Assert.Equal(expiresAt, callbackData.ExpiresAt);
             Assert.Null(callbackData.TenantCustomDomain);
             Assert.Null(callbackData.CustomState);
             Assert.Null(callbackData.ReturnUrl);
@@ -101,6 +113,7 @@ namespace Wristband.AspNet.Auth.Tests
             var empty = CallbackData.Empty;
 
             Assert.Equal("empty", empty.AccessToken);
+            Assert.Equal(0, empty.ExpiresAt);
             Assert.Equal(0, empty.ExpiresIn);
             Assert.Equal("empty", empty.IdToken);
             Assert.Null(empty.RefreshToken);
@@ -109,6 +122,78 @@ namespace Wristband.AspNet.Auth.Tests
             Assert.Null(empty.TenantCustomDomain);
             Assert.Null(empty.CustomState);
             Assert.Null(empty.ReturnUrl);
+        }
+
+        [Fact]
+        public void Constructor_InheritsTokenDataValidation_NegativeExpiresAt()
+        {
+            // Test that TokenData validation is inherited
+            Assert.Throws<InvalidOperationException>(() => new CallbackData(
+                accessToken: "token",
+                expiresAt: -1,
+                expiresIn: 3600,
+                idToken: "id_token",
+                refreshToken: "refresh_token",
+                userinfo: new UserInfo("{}"),
+                tenantDomainName: "example.com",
+                tenantCustomDomain: null,
+                customState: null,
+                returnUrl: null
+            ));
+        }
+
+        [Fact]
+        public void Constructor_InheritsTokenDataValidation_NegativeExpiresIn()
+        {
+            // Test that TokenData validation is inherited
+            Assert.Throws<InvalidOperationException>(() => new CallbackData(
+                accessToken: "token",
+                expiresAt: DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds(),
+                expiresIn: -1,
+                idToken: "id_token",
+                refreshToken: "refresh_token",
+                userinfo: new UserInfo("{}"),
+                tenantDomainName: "example.com",
+                tenantCustomDomain: null,
+                customState: null,
+                returnUrl: null
+            ));
+        }
+
+        [Fact]
+        public void Constructor_InheritsTokenDataValidation_NullAccessToken()
+        {
+            // Test that TokenData validation is inherited
+            Assert.Throws<InvalidOperationException>(() => new CallbackData(
+                accessToken: null!,
+                expiresAt: DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds(),
+                expiresIn: 3600,
+                idToken: "id_token",
+                refreshToken: "refresh_token",
+                userinfo: new UserInfo("{}"),
+                tenantDomainName: "example.com",
+                tenantCustomDomain: null,
+                customState: null,
+                returnUrl: null
+            ));
+        }
+
+        [Fact]
+        public void Constructor_InheritsTokenDataValidation_NullIdToken()
+        {
+            // Test that TokenData validation is inherited
+            Assert.Throws<InvalidOperationException>(() => new CallbackData(
+                accessToken: "token",
+                expiresAt: DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds(),
+                expiresIn: 3600,
+                idToken: null!,
+                refreshToken: "refresh_token",
+                userinfo: new UserInfo("{}"),
+                tenantDomainName: "example.com",
+                tenantCustomDomain: null,
+                customState: null,
+                returnUrl: null
+            ));
         }
     }
 }

--- a/tests/types-and-dtos/public/TokenDataTests.cs
+++ b/tests/types-and-dtos/public/TokenDataTests.cs
@@ -7,18 +7,40 @@ namespace Wristband.AspNet.Auth.Tests
         {
             // Arrange
             var accessToken = "testAccessToken";
+            var expiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
             var expiresIn = 3600;
             var idToken = "testIdToken";
             var refreshToken = "testRefreshToken";
 
             // Act
-            var tokenData = new TokenData(accessToken, expiresIn, idToken, refreshToken);
+            var tokenData = new TokenData(accessToken, expiresAt, expiresIn, idToken, refreshToken);
 
             // Assert
             Assert.Equal(accessToken, tokenData.AccessToken);
+            Assert.Equal(expiresAt, tokenData.ExpiresAt);
             Assert.Equal(expiresIn, tokenData.ExpiresIn);
             Assert.Equal(idToken, tokenData.IdToken);
             Assert.Equal(refreshToken, tokenData.RefreshToken);
+        }
+
+        [Fact]
+        public void Constructor_ShouldInitializeProperties_WhenRefreshTokenIsNull()
+        {
+            // Arrange
+            var accessToken = "testAccessToken";
+            var expiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeMilliseconds();
+            var expiresIn = 3600;
+            var idToken = "testIdToken";
+
+            // Act
+            var tokenData = new TokenData(accessToken, expiresAt, expiresIn, idToken, null);
+
+            // Assert
+            Assert.Equal(accessToken, tokenData.AccessToken);
+            Assert.Equal(expiresAt, tokenData.ExpiresAt);
+            Assert.Equal(expiresIn, tokenData.ExpiresIn);
+            Assert.Equal(idToken, tokenData.IdToken);
+            Assert.Null(tokenData.RefreshToken);
         }
 
         [Theory]
@@ -27,16 +49,25 @@ namespace Wristband.AspNet.Auth.Tests
         public void Constructor_ShouldThrowException_WhenAccessTokenIsInvalid(string invalidAccessToken)
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                new TokenData(invalidAccessToken, 3600, "validIdToken", "validRefreshToken"));
+                new TokenData(invalidAccessToken, 1234567890000, 3600, "validIdToken", "validRefreshToken"));
 
             Assert.Equal("[AccessToken] cannot be null or empty.", exception.Message);
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowException_WhenExpiresAtIsNegative()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new TokenData("validAccessToken", -1, 3600, "validIdToken", "validRefreshToken"));
+
+            Assert.Equal("[ExpiresAt] must be a non-negative integer.", exception.Message);
         }
 
         [Fact]
         public void Constructor_ShouldThrowException_WhenExpiresInIsNegative()
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                new TokenData("validAccessToken", -1, "validIdToken", "validRefreshToken"));
+                new TokenData("validAccessToken", 1234567890000, -1, "validIdToken", "validRefreshToken"));
 
             Assert.Equal("[ExpiresIn] must be a non-negative integer.", exception.Message);
         }
@@ -47,9 +78,39 @@ namespace Wristband.AspNet.Auth.Tests
         public void Constructor_ShouldThrowException_WhenIdTokenIsInvalid(string invalidIdToken)
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                new TokenData("validAccessToken", 3600, invalidIdToken, "validRefreshToken"));
+                new TokenData("validAccessToken", 1234567890000, 3600, invalidIdToken, "validRefreshToken"));
 
             Assert.Equal("[IdToken] cannot be null or empty.", exception.Message);
+        }
+
+        [Fact]
+        public void Constructor_ShouldAllowZeroExpiresAt()
+        {
+            // Act & Assert - should not throw
+            var tokenData = new TokenData("validAccessToken", 0, 3600, "validIdToken", "validRefreshToken");
+
+            Assert.Equal(0, tokenData.ExpiresAt);
+        }
+
+        [Fact]
+        public void Constructor_ShouldAllowZeroExpiresIn()
+        {
+            // Act & Assert - should not throw
+            var tokenData = new TokenData("validAccessToken", 1234567890000, 0, "validIdToken", "validRefreshToken");
+
+            Assert.Equal(0, tokenData.ExpiresIn);
+        }
+
+        [Fact]
+        public void Constructor_ShouldAllowLargeExpiresAtValue()
+        {
+            // Arrange - test with a large timestamp (year 2050)
+            var largeExpiresAt = 2524608000000L; // January 1, 2050
+
+            // Act & Assert - should not throw
+            var tokenData = new TokenData("validAccessToken", largeExpiresAt, 3600, "validIdToken", "validRefreshToken");
+
+            Assert.Equal(largeExpiresAt, tokenData.ExpiresAt);
         }
     }
 }

--- a/tests/types-and-dtos/public/WristbandAuthConfigTests.cs
+++ b/tests/types-and-dtos/public/WristbandAuthConfigTests.cs
@@ -19,6 +19,7 @@ namespace Wristband.AspNet.Auth.Tests
             Assert.Empty(config.Scopes);
             Assert.False(config.DangerouslyDisableSecureCookies);
             Assert.False(config.IsApplicationCustomDomainActive);
+            Assert.Equal(60, config.TokenExpirationBuffer);
         }
 
         [Fact]
@@ -35,6 +36,7 @@ namespace Wristband.AspNet.Auth.Tests
             var rootDomain = "example.com";
             var scopes = new List<string> { "openid", "profile", "email" };
             var isApplicationCustomDomainActive = true;
+            var tokenExpirationBuffer = 120;
 
             var config = new WristbandAuthConfig(
                 clientId,
@@ -47,7 +49,8 @@ namespace Wristband.AspNet.Auth.Tests
                 dangerouslyDisableSecureCookies,
                 rootDomain,
                 scopes,
-                isApplicationCustomDomainActive
+                isApplicationCustomDomainActive,
+                tokenExpirationBuffer
             );
 
             Assert.Equal(clientId, config.ClientId);
@@ -62,12 +65,13 @@ namespace Wristband.AspNet.Auth.Tests
             Assert.Equal(scopes, config.Scopes);
             Assert.True(config.DangerouslyDisableSecureCookies);
             Assert.True(config.IsApplicationCustomDomainActive);
+            Assert.Equal(tokenExpirationBuffer, config.TokenExpirationBuffer);
         }
 
         [Fact]
         public void Constructor_WithNullValues_ShouldSetPropertiesToNullOrDefaults()
         {
-            var config = new WristbandAuthConfig(null, null, null, null, null, null, null, null, null, null, null);
+            var config = new WristbandAuthConfig(null, null, null, null, null, null, null, null, null, null, null, null);
 
             Assert.Null(config.ClientId);
             Assert.Null(config.ClientSecret);
@@ -80,6 +84,7 @@ namespace Wristband.AspNet.Auth.Tests
             Assert.Null(config.Scopes);
             Assert.Null(config.DangerouslyDisableSecureCookies);
             Assert.Null(config.IsApplicationCustomDomainActive);
+            Assert.Null(config.TokenExpirationBuffer);
         }
 
         [Fact]
@@ -98,6 +103,7 @@ namespace Wristband.AspNet.Auth.Tests
             config.ParseTenantFromRootDomain = "updated-example.com";
             config.Scopes = new List<string> { "custom-scope" };
             config.IsApplicationCustomDomainActive = true;
+            config.TokenExpirationBuffer = 90;
 
             Assert.Equal("updated-client-id", config.ClientId);
             Assert.Equal("updated-client-secret", config.ClientSecret);
@@ -112,6 +118,60 @@ namespace Wristband.AspNet.Auth.Tests
             Assert.Equal("custom-scope", config.Scopes[0]);
             Assert.True(config.DangerouslyDisableSecureCookies);
             Assert.True(config.IsApplicationCustomDomainActive);
+            Assert.Equal(90, config.TokenExpirationBuffer);
+        }
+
+        [Fact]
+        public void Constructor_WithSpecificTokenExpirationBuffer_ShouldSetValue()
+        {
+            var tokenExpirationBuffer = 300;
+
+            var config = new WristbandAuthConfig(
+                clientId: null,
+                clientSecret: null,
+                loginStateSecret: null,
+                loginUrl: null,
+                redirectUri: null,
+                wristbandApplicationVanityDomain: null,
+                customApplicationLoginPageUrl: null,
+                dangerouslyDisableSecureCookies: null,
+                parseTenantFromRootDomain: null,
+                scopes: null,
+                isApplicationCustomDomainActive: null,
+                tokenExpirationBuffer: tokenExpirationBuffer
+            );
+
+            Assert.Equal(tokenExpirationBuffer, config.TokenExpirationBuffer);
+        }
+
+        [Fact]
+        public void Constructor_WithZeroTokenExpirationBuffer_ShouldSetValue()
+        {
+            var config = new WristbandAuthConfig(
+                clientId: null,
+                clientSecret: null,
+                loginStateSecret: null,
+                loginUrl: null,
+                redirectUri: null,
+                wristbandApplicationVanityDomain: null,
+                customApplicationLoginPageUrl: null,
+                dangerouslyDisableSecureCookies: null,
+                parseTenantFromRootDomain: null,
+                scopes: null,
+                isApplicationCustomDomainActive: null,
+                tokenExpirationBuffer: 0
+            );
+
+            Assert.Equal(0, config.TokenExpirationBuffer);
+        }
+
+        [Fact]
+        public void TokenExpirationBuffer_ShouldHaveDefaultValue60()
+        {
+            // Test that the property has the default value when using parameterless constructor
+            var config = new WristbandAuthConfig();
+
+            Assert.Equal(60, config.TokenExpirationBuffer);
         }
     }
 }


### PR DESCRIPTION
- Add TokenExpirationBuffer configurations to `WristbandAuthConfig`
- Return an `ExpiresAt` field as part of the `CallbackData` and `TokenData` types
- Allow for any 32+ character string to be accepted as a login state secret