### PR TITLE
Release 3.0.0

### DIFF
--- a/migration/v3/README.md
+++ b/migration/v3/README.md
@@ -1,0 +1,97 @@
+<div align="center">
+  <a href="https://wristband.dev">
+    <picture>
+      <img src="https://assets.wristband.dev/images/email_branding_logo_v1.png" alt="Github" width="297" height="64">
+    </picture>
+  </a>
+  <p align="center">
+    Migration instruction from version v2.x to version v3.x
+  </p>
+  <p align="center">
+    <b>
+      <a href="https://wristband.dev">Website</a> • 
+      <a href="https://docs.wristband.dev/">Documentation</a>
+    </b>
+  </p>
+</div>
+
+<br/>
+
+---
+
+<br/>
+
+# Migration instruction from version v2.x to version v3.x
+
+**Legend:**
+
+- (`-`) indicates the older version of the code that needs to be changed
+- (`+`) indicates the new and correct version of the code for version 3.x
+
+<br>
+
+## Table of Contents
+
+- [SDK Registration Method Changes](#sdk-registration-method-changes)
+
+<br>
+
+## SDK Registration Method Changes
+
+The deprecated `AddWristbandAuth()` method that accepted `IConfiguration` and `configSectionName` parameters has been removed in version 3.x. You must now use the direct configuration approach.
+
+### Old Method (Removed in v3.x)
+
+```csharp
+// Program.cs
+builder.Services.AddWristbandAuth(builder.Configuration, "WristbandAuthConfig");
+```
+
+<br>
+
+### Expected Methods (Required in v3.x)
+
+The configuration file structure (`appsettings.json`) remains the same, but you must now explicitly bind the configuration values in your `Program.cs` file rather than relying on the deprecated automatic configuration binding method.
+
+**Default Singleton Service**
+```csharp
+// Program.cs
+builder.Services.AddWristbandAuth(options =>
+{
+    var authConfig = builder.Configuration.GetSection("WristbandAuthConfig");
+    options.ClientId = authConfig["ClientId"];
+    options.ClientSecret = authConfig["ClientSecret"];
+    options.WristbandApplicationVanityDomain = authConfig["WristbandApplicationVanityDomain"];
+    // Configure other options as needed...
+});
+```
+
+**Named Services**
+```csharp
+// Program.cs
+builder.Services.AddWristbandAuth("auth01", options =>
+{
+    var auth01Config = builder.Configuration.GetSection("WristbandAuthConfig:auth01");
+    options.ClientId = auth01Config["ClientId"];
+    options.ClientSecret = auth01Config["ClientSecret"];
+    options.WristbandApplicationVanityDomain = auth01Config["WristbandApplicationVanityDomain"];
+    // Configure other options as needed...
+});
+ 
+builder.Services.AddWristbandAuth("auth02", options =>
+{
+    var auth02Config = builder.Configuration.GetSection("WristbandAuthConfig:auth02");
+    options.ClientId = auth02Config["ClientId"];
+    options.ClientSecret = auth02Config["ClientSecret"];
+    options.WristbandApplicationVanityDomain = auth02Config["WristbandApplicationVanityDomain"];
+    // Configure other options as needed...
+});
+```
+
+<br>
+
+## Questions
+
+Reach out to the Wristband team at <support@wristband.dev> for any questions around migration.
+
+<br/>

--- a/src/ConfigResolver.cs
+++ b/src/ConfigResolver.cs
@@ -1,0 +1,466 @@
+namespace Wristband.AspNet.Auth;
+
+/// <summary>
+/// Handles configuration resolution for Wristband authentication, supporting both manual configuration
+/// and auto-configuration from the Wristband SDK Configuration Endpoint.
+/// </summary>
+internal class ConfigResolver
+{
+    private const string TenantDomainToken = "{tenant_domain}";
+    private const int DefaultTokenExpirationBuffer = 60; // 60 seconds
+    private const int MaxFetchAttempts = 3;
+    private const int AttemptDelayMs = 100; // 100 milliseconds
+    private static readonly List<string> DefaultScopes = new List<string> { "openid", "offline_access", "email" };
+
+    private readonly WristbandAuthConfig _authConfig;
+    private readonly IWristbandApiClient _wristbandApiClient;
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private SdkConfiguration? _cachedSdkConfig;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigResolver"/> class.
+    /// </summary>
+    /// <param name="authConfig">The authentication configuration.</param>
+    /// <param name="wristbandApiClient">The Wristband API client for fetching SDK configuration.</param>
+    public ConfigResolver(WristbandAuthConfig authConfig, IWristbandApiClient wristbandApiClient)
+    {
+        _authConfig = authConfig ?? throw new ArgumentNullException(nameof(authConfig));
+        _wristbandApiClient = wristbandApiClient ?? throw new ArgumentNullException(nameof(wristbandApiClient));
+
+        // Always validate required configurations
+        ValidateRequiredAuthConfigs();
+
+        if (GetAutoConfigureEnabled())
+        {
+            // Only validate manually provided values when auto-configure is enabled
+            ValidatePartialUrlAuthConfigs();
+        }
+        else
+        {
+            // Validate all configurations if auto-configure is disabled
+            ValidateStrictUrlAuthConfigs();
+        }
+    }
+
+    /// <summary>
+    /// Forces loading and caching of all auto-configurable fields.
+    /// This will trigger the API call and cache the results.
+    /// Any validation errors will be thrown here (fail-fast).
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <exception cref="WristbandError">Thrown when auto-configure is disabled or configuration fails.</exception>
+    public async Task PreloadConfig()
+    {
+        if (!GetAutoConfigureEnabled())
+        {
+            throw new WristbandError(
+                "config_error",
+                "Cannot preload configs when AutoConfigureEnabled is false. Set AutoConfigureEnabled to true.");
+        }
+
+        await LoadSdkConfig();
+    }
+
+    /// <summary>
+    /// Gets the client ID from the authentication configuration.
+    /// </summary>
+    /// <returns>The client ID.</returns>
+    public string GetClientId()
+    {
+        return _authConfig.ClientId ?? throw new InvalidOperationException("ClientId is required");
+    }
+
+    /// <summary>
+    /// Gets the client secret from the authentication configuration.
+    /// </summary>
+    /// <returns>The client secret.</returns>
+    public string GetClientSecret()
+    {
+        return _authConfig.ClientSecret ?? throw new InvalidOperationException("ClientSecret is required");
+    }
+
+    /// <summary>
+    /// Gets the login state secret, defaulting to client secret if not specified.
+    /// </summary>
+    /// <returns>The login state secret.</returns>
+    public string GetLoginStateSecret()
+    {
+        return _authConfig.LoginStateSecret ?? GetClientSecret();
+    }
+
+    /// <summary>
+    /// Gets the Wristband application vanity domain.
+    /// </summary>
+    /// <returns>The Wristband application vanity domain.</returns>
+    public string GetWristbandApplicationVanityDomain()
+    {
+        return _authConfig.WristbandApplicationVanityDomain ??
+               throw new InvalidOperationException("WristbandApplicationVanityDomain is required");
+    }
+
+    /// <summary>
+    /// Gets whether secure cookies are disabled (for development only).
+    /// </summary>
+    /// <returns>True if secure cookies are disabled; otherwise, false.</returns>
+    public bool GetDangerouslyDisableSecureCookies()
+    {
+        return _authConfig.DangerouslyDisableSecureCookies.GetValueOrDefault(false);
+    }
+
+    /// <summary>
+    /// Gets the authentication scopes, defaulting to standard OpenID scopes.
+    /// </summary>
+    /// <returns>A list of authentication scopes.</returns>
+    public List<string> GetScopes()
+    {
+        return _authConfig.Scopes?.Any() == true ? _authConfig.Scopes : DefaultScopes;
+    }
+
+    /// <summary>
+    /// Gets whether auto-configuration is enabled (true by default).
+    /// </summary>
+    /// <returns>True if auto-configuration is enabled; otherwise, false.</returns>
+    public bool GetAutoConfigureEnabled()
+    {
+        return _authConfig.AutoConfigureEnabled.GetValueOrDefault(true);
+    }
+
+    /// <summary>
+    /// Gets the token expiration buffer in seconds.
+    /// </summary>
+    /// <returns>The token expiration buffer in seconds.</returns>
+    public int GetTokenExpirationBuffer()
+    {
+        return _authConfig.TokenExpirationBuffer.GetValueOrDefault(DefaultTokenExpirationBuffer);
+    }
+
+    /// <summary>
+    /// Gets the custom application login page URL.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the custom application login page URL, or null if not configured.</returns>
+    public async Task<string> GetCustomApplicationLoginPageUrl()
+    {
+        // 1. Check if manually provided in authConfig
+        if (!string.IsNullOrEmpty(_authConfig.CustomApplicationLoginPageUrl))
+        {
+            return _authConfig.CustomApplicationLoginPageUrl;
+        }
+
+        // 2. If auto-configure is enabled, get from SDK config
+        if (GetAutoConfigureEnabled())
+        {
+            var sdkConfig = await LoadSdkConfig();
+            return sdkConfig.CustomApplicationLoginPageUrl ?? string.Empty;
+        }
+
+        // 3. Default fallback
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Gets whether the application custom domain is active.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains true if the application custom domain is active; otherwise, false.</returns>
+    public async Task<bool> GetIsApplicationCustomDomainActive()
+    {
+        // 1. Check if manually provided in authConfig
+        if (_authConfig.IsApplicationCustomDomainActive.HasValue)
+        {
+            return _authConfig.IsApplicationCustomDomainActive.Value;
+        }
+
+        // 2. If auto-configure is enabled, get from SDK config
+        if (GetAutoConfigureEnabled())
+        {
+            var sdkConfig = await LoadSdkConfig();
+            return sdkConfig.IsApplicationCustomDomainActive;
+        }
+
+        // 3. Default fallback
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the login URL.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the login URL.</returns>
+    public async Task<string> GetLoginUrl()
+    {
+        // 1. Check if manually provided in authConfig
+        if (!string.IsNullOrEmpty(_authConfig.LoginUrl))
+        {
+            return _authConfig.LoginUrl;
+        }
+
+        // 2. If auto-configure is enabled, get from SDK config
+        if (GetAutoConfigureEnabled())
+        {
+            var sdkConfig = await LoadSdkConfig();
+            return sdkConfig.LoginUrl;
+        }
+
+        // 3. This should not happen if validation is done properly
+        throw new InvalidOperationException("LoginUrl must have a value");
+    }
+
+    /// <summary>
+    /// Gets the root domain for parsing tenant subdomains.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the root domain for parsing tenant subdomains, or null if not configured.</returns>
+    public async Task<string> GetParseTenantFromRootDomain()
+    {
+        // 1. Check if manually provided in authConfig
+        if (!string.IsNullOrEmpty(_authConfig.ParseTenantFromRootDomain))
+        {
+            return _authConfig.ParseTenantFromRootDomain;
+        }
+
+        // 2. If auto-configure is enabled, get from SDK config
+        if (GetAutoConfigureEnabled())
+        {
+            var sdkConfig = await LoadSdkConfig();
+            return sdkConfig.LoginUrlTenantDomainSuffix ?? string.Empty;
+        }
+
+        // 3. Default fallback
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the redirect URI.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the redirect URI.</returns>
+    public async Task<string> GetRedirectUri()
+    {
+        // 1. Check if manually provided in authConfig
+        if (!string.IsNullOrEmpty(_authConfig.RedirectUri))
+        {
+            return _authConfig.RedirectUri;
+        }
+
+        // 2. If auto-configure is enabled, get from SDK config
+        if (GetAutoConfigureEnabled())
+        {
+            var sdkConfig = await LoadSdkConfig();
+            return sdkConfig.RedirectUri;
+        }
+
+        // 3. This should not happen if validation is done properly
+        throw new InvalidOperationException("RedirectUri must have a value");
+    }
+
+    private async Task<SdkConfiguration> LoadSdkConfig()
+    {
+        if (_cachedSdkConfig != null)
+        {
+            return _cachedSdkConfig;
+        }
+
+        await _semaphore.WaitAsync();
+
+        try
+        {
+            if (_cachedSdkConfig != null)
+            {
+                return _cachedSdkConfig;
+            }
+
+            var config = await FetchSdkConfiguration();
+            ValidateAllDynamicConfigs(config);
+            _cachedSdkConfig = config; // Only cache on success
+            return config;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private async Task<SdkConfiguration> FetchSdkConfiguration()
+    {
+        Exception? lastError = null;
+
+        for (int attempt = 1; attempt <= MaxFetchAttempts; attempt++)
+        {
+            try
+            {
+                return await _wristbandApiClient.GetSdkConfiguration();
+            }
+            catch (Exception error)
+            {
+                lastError = error;
+
+                // Final attempt failed, throw the error
+                if (attempt == MaxFetchAttempts)
+                {
+                    break;
+                }
+
+                // Wait before retrying
+                await Task.Delay(AttemptDelayMs);
+            }
+        }
+
+        throw new WristbandError(
+            "sdk_config_error",
+            $"Failed to fetch SDK configuration after {MaxFetchAttempts} attempts: {lastError?.Message ?? "Unknown error"}");
+    }
+
+    private void ValidateRequiredAuthConfigs()
+    {
+        if (string.IsNullOrWhiteSpace(_authConfig.ClientId))
+        {
+            throw new ArgumentException("The [ClientId] config must have a value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_authConfig.ClientSecret))
+        {
+            throw new ArgumentException("The [ClientSecret] config must have a value.");
+        }
+
+        if (!string.IsNullOrEmpty(_authConfig.LoginStateSecret) && _authConfig.LoginStateSecret.Length < 32)
+        {
+            throw new ArgumentException("The [LoginStateSecret] config must have a value of at least 32 characters.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_authConfig.WristbandApplicationVanityDomain))
+        {
+            throw new ArgumentException("The [WristbandApplicationVanityDomain] config must have a value.");
+        }
+
+        if (_authConfig.TokenExpirationBuffer.HasValue && _authConfig.TokenExpirationBuffer.Value < 0)
+        {
+            throw new ArgumentException("The [TokenExpirationBuffer] config must be greater than or equal to 0.");
+        }
+    }
+
+    private void ValidateStrictUrlAuthConfigs()
+    {
+        if (string.IsNullOrWhiteSpace(_authConfig.LoginUrl))
+        {
+            throw new ArgumentException("The [LoginUrl] config must have a value when auto-configure is disabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_authConfig.RedirectUri))
+        {
+            throw new ArgumentException("The [RedirectUri] config must have a value when auto-configure is disabled.");
+        }
+
+        var hasRootDomain = !string.IsNullOrEmpty(_authConfig.ParseTenantFromRootDomain);
+        var loginUrlHasToken = _authConfig.LoginUrl.Contains(TenantDomainToken);
+        var redirectUriHasToken = _authConfig.RedirectUri.Contains(TenantDomainToken);
+
+        if (hasRootDomain && !loginUrlHasToken)
+        {
+            throw new ArgumentException(
+                $"The [LoginUrl] must contain the \"{TenantDomainToken}\" token when using the [ParseTenantFromRootDomain] config.");
+        }
+
+        if (!hasRootDomain && loginUrlHasToken)
+        {
+            throw new ArgumentException(
+                $"The [LoginUrl] cannot contain the \"{TenantDomainToken}\" token when the [ParseTenantFromRootDomain] is absent.");
+        }
+
+        if (hasRootDomain && !redirectUriHasToken)
+        {
+            throw new ArgumentException(
+                $"The [RedirectUri] must contain the \"{TenantDomainToken}\" token when using the [ParseTenantFromRootDomain] config.");
+        }
+
+        if (!hasRootDomain && redirectUriHasToken)
+        {
+            throw new ArgumentException(
+                $"The [RedirectUri] cannot contain the \"{TenantDomainToken}\" token when the [ParseTenantFromRootDomain] is absent.");
+        }
+    }
+
+    private void ValidatePartialUrlAuthConfigs()
+    {
+        var hasRootDomain = !string.IsNullOrEmpty(_authConfig.ParseTenantFromRootDomain);
+
+        if (!string.IsNullOrEmpty(_authConfig.LoginUrl))
+        {
+            var hasToken = _authConfig.LoginUrl.Contains(TenantDomainToken);
+            if (hasRootDomain && !hasToken)
+            {
+                throw new ArgumentException(
+                    $"The [LoginUrl] must contain the \"{TenantDomainToken}\" token when using the [ParseTenantFromRootDomain] config.");
+            }
+
+            if (!hasRootDomain && hasToken)
+            {
+                throw new ArgumentException(
+                    $"The [LoginUrl] cannot contain the \"{TenantDomainToken}\" token when the [ParseTenantFromRootDomain] is absent.");
+            }
+        }
+
+        if (!string.IsNullOrEmpty(_authConfig.RedirectUri))
+        {
+            var hasToken = _authConfig.RedirectUri.Contains(TenantDomainToken);
+            if (hasRootDomain && !hasToken)
+            {
+                throw new ArgumentException(
+                    $"The [RedirectUri] must contain the \"{TenantDomainToken}\" token when using the [ParseTenantFromRootDomain] config.");
+            }
+
+            if (!hasRootDomain && hasToken)
+            {
+                throw new ArgumentException(
+                    $"The [RedirectUri] cannot contain the \"{TenantDomainToken}\" token when the [ParseTenantFromRootDomain] is absent.");
+            }
+        }
+    }
+
+    private void ValidateAllDynamicConfigs(SdkConfiguration sdkConfiguration)
+    {
+        // Validate that required fields are present in the SDK config response
+        if (string.IsNullOrEmpty(sdkConfiguration.LoginUrl))
+        {
+            throw new WristbandError("sdk_config_error", "SDK configuration response missing required field: LoginUrl");
+        }
+
+        if (string.IsNullOrEmpty(sdkConfiguration.RedirectUri))
+        {
+            throw new WristbandError("sdk_config_error", "SDK configuration response missing required field: RedirectUri");
+        }
+
+        // Use manual config values if provided, otherwise use SDK config values
+        var loginUrl = _authConfig.LoginUrl ?? sdkConfiguration.LoginUrl;
+        var redirectUri = _authConfig.RedirectUri ?? sdkConfiguration.RedirectUri;
+        var parseTenantFromRootDomain = _authConfig.ParseTenantFromRootDomain ??
+                                       sdkConfiguration.LoginUrlTenantDomainSuffix;
+
+        var hasRootDomain = !string.IsNullOrEmpty(parseTenantFromRootDomain);
+        var loginUrlHasToken = loginUrl.Contains(TenantDomainToken);
+        var redirectUriHasToken = redirectUri.Contains(TenantDomainToken);
+
+        if (hasRootDomain && !loginUrlHasToken)
+        {
+            throw new WristbandError(
+                "config_validation_error",
+                $"The resolved [LoginUrl] must contain the \"{TenantDomainToken}\" token when using [ParseTenantFromRootDomain].");
+        }
+
+        if (!hasRootDomain && loginUrlHasToken)
+        {
+            throw new WristbandError(
+                "config_validation_error",
+                $"The resolved [LoginUrl] cannot contain the \"{TenantDomainToken}\" token when [ParseTenantFromRootDomain] is absent.");
+        }
+
+        if (hasRootDomain && !redirectUriHasToken)
+        {
+            throw new WristbandError(
+                "config_validation_error",
+                $"The resolved [RedirectUri] must contain the \"{TenantDomainToken}\" token when using [ParseTenantFromRootDomain].");
+        }
+
+        if (!hasRootDomain && redirectUriHasToken)
+        {
+            throw new WristbandError(
+                "config_validation_error",
+                $"The resolved [RedirectUri] cannot contain the \"{TenantDomainToken}\" token when [ParseTenantFromRootDomain] is absent.");
+        }
+    }
+}

--- a/src/ILoginStateHandler.cs
+++ b/src/ILoginStateHandler.cs
@@ -12,9 +12,10 @@ internal interface ILoginStateHandler
     /// </summary>
     /// <param name="httpContext">The HTTP context for the request, containing details about the login request.</param>
     /// <param name="redirectUri">The redirect URI for callback after authentication.</param>
+    /// <param name="returnUrl">The URL to return to after authentication. Takes precedence over return_url query parameter.</param>
     /// <param name="customState">Custom state data for the login request.</param>
     /// <returns> A <see cref="LoginState"/> for the current login request.</returns>
-    LoginState CreateLoginState(HttpContext httpContext, string redirectUri, Dictionary<string, object>? customState);
+    LoginState CreateLoginState(HttpContext httpContext, string redirectUri, string? returnUrl, Dictionary<string, object>? customState);
 
     /// <summary>
     /// Sets a response cookie containing the login state to be preserved until the time of callback processing.

--- a/src/IWristbandApiClient.cs
+++ b/src/IWristbandApiClient.cs
@@ -6,6 +6,12 @@ namespace Wristband.AspNet.Auth;
 internal interface IWristbandApiClient
 {
     /// <summary>
+    /// Gets the SDK configuration from the Wristband platform.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation that returns the SDK configuration.</returns>
+    Task<SdkConfiguration> GetSdkConfiguration();
+
+    /// <summary>
     /// Calls the Wristband Token Endpoint with the authorization code grant type to exchange an authorization code for tokens.
     /// </summary>
     /// <param name="code">The authorization code received from the OAuth2 authorization server.</param>

--- a/src/IWristbandAuthService.cs
+++ b/src/IWristbandAuthService.cs
@@ -9,6 +9,16 @@ namespace Wristband.AspNet.Auth;
 public interface IWristbandAuthService
 {
     /// <summary>
+    /// Immediately fetch and resolve all auto-configuration values from the Wristband SDK Configuration Endpoint.
+    /// This is useful when you want to fail fast if auto-configuration is unavailable, or when you need configuration
+    /// values resolved before making any auth method calls. Manual configuration values take precedence over
+    /// auto-configured values.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <exception cref="WristbandError">Thrown when auto-configure is disabled or configuration fails.</exception>
+    Task Discover();
+
+    /// <summary>
     /// Generates the authorization URL for initiating a login request with Wristband.
     /// </summary>
     /// <param name="context">The HTTP context for the request, containing details about the login request.</param>

--- a/src/LoginStateHandler.cs
+++ b/src/LoginStateHandler.cs
@@ -24,31 +24,18 @@ internal class LoginStateHandler : ILoginStateHandler
     /// Implements <see cref="ILoginStateHandler.CreateLoginState"/>.
     /// </summary>
     /// <inheritdoc />
-    public LoginState CreateLoginState(HttpContext httpContext, string redirectUri, Dictionary<string, object>? customState)
+    public LoginState CreateLoginState(
+        HttpContext httpContext,
+        string redirectUri,
+        string? returnUrl,
+        Dictionary<string, object>? customState)
     {
-        var returnUrl = string.Empty;
-
-        if (httpContext.Request.Query.TryGetValue("return_url", out var returnUrlValue))
-        {
-            if (returnUrlValue.Count > 1)
-            {
-                throw new ArgumentException("More than one [return_url] query parameter was encountered.");
-            }
-
-            returnUrl = returnUrlValue.ToString();
-        }
-
-        if (returnUrl.Contains(" "))
-        {
-            throw new ArgumentException("Return URL should not contain spaces.");
-        }
-
         return new LoginState(
-            GenerateRandomString(32),
-            GenerateRandomString(32),
-            redirectUri,
-            returnUrl,
-            customState);
+            state: GenerateRandomString(32),
+            codeVerifier: GenerateRandomString(32),
+            redirectUri: redirectUri,
+            returnUrl: returnUrl,
+            customState: customState);
     }
 
     /// <summary>

--- a/src/Wristband.AspNet.Auth.csproj
+++ b/src/Wristband.AspNet.Auth.csproj
@@ -45,7 +45,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/extensions/WristbandAuthServiceExtensions.cs
+++ b/src/extensions/WristbandAuthServiceExtensions.cs
@@ -11,34 +11,6 @@ namespace Wristband.AspNet.Auth;
 public static class WristbandAuthServiceExtensions
 {
     /// <summary>
-    /// ** TODO: This is deprecated. Left here for backwards compatibility. Remove in next major version release.
-    /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
-    /// <param name="configuration">The configuration instance to read settings from.</param>
-    /// <param name="configSectionName">The configuration section name for Wristband auth settings. Defaults to "WristbandAuthConfig".</param>
-    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-    public static IServiceCollection AddWristbandAuth(
-        this IServiceCollection services,
-        IConfiguration configuration,
-        string configSectionName = "WristbandAuthConfig")
-    {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(configuration);
-
-        services.Configure<WristbandAuthConfig>(configuration.GetSection(configSectionName));
-        services.AddScoped<IWristbandAuthService>(serviceProvider =>
-        {
-            var authConfig = serviceProvider.GetRequiredService<IOptions<WristbandAuthConfig>>().Value;
-            return new WristbandAuthService(authConfig, null);
-        });
-
-        // Register the service factory if not already registered
-        services.TryAddSingleton<WristbandAuthServiceFactory>();
-
-        return services;
-    }
-
-    /// <summary>
     /// Adds Wristband authentication services to the service collection using direct configuration.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
@@ -54,7 +26,7 @@ public static class WristbandAuthServiceExtensions
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         services.Configure(configureOptions);
-        services.AddScoped<IWristbandAuthService>(serviceProvider =>
+        services.AddSingleton<IWristbandAuthService>(serviceProvider =>
         {
             var authConfig = serviceProvider.GetRequiredService<IOptions<WristbandAuthConfig>>().Value;
 

--- a/src/types-and-dtos/internal/LoginState.cs
+++ b/src/types-and-dtos/internal/LoginState.cs
@@ -20,7 +20,7 @@ internal class LoginState
         string state,
         string codeVerifier,
         string redirectUri,
-        string returnUrl,
+        string? returnUrl,
         Dictionary<string, object>? customState)
     {
         if (string.IsNullOrEmpty(state))

--- a/src/types-and-dtos/internal/SdkConfiguration.cs
+++ b/src/types-and-dtos/internal/SdkConfiguration.cs
@@ -1,0 +1,55 @@
+using System.Text.Json.Serialization;
+
+namespace Wristband.AspNet.Auth;
+
+/// <summary>
+/// Configuration object containing URLs and settings discovered from the Wristband SDK Configuration Endpoint.
+/// These values are auto-configured by calling the Wristband SDK Configuration API.
+/// </summary>
+internal class SdkConfiguration
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdkConfiguration"/> class.
+    /// </summary>
+    public SdkConfiguration()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the custom Application-Level Login Page URL (i.e. Tenant Discovery Page URL).
+    /// This value is only needed if you are self-hosting the application login page.
+    /// When null, the SDK will use your Wristband-hosted Application-Level Login page URL.
+    /// </summary>
+    [JsonPropertyName("customApplicationLoginPageUrl")]
+    public string? CustomApplicationLoginPageUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether gets or sets whether your Wristband application is configured with an
+    /// application-level custom domain that is active. This tells the SDK which URL format to use when constructing
+    /// the Wristband Authorize Endpoint URL.
+    /// </summary>
+    [JsonPropertyName("isApplicationCustomDomainActive")]
+    public bool IsApplicationCustomDomainActive { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URL of your application's login endpoint that redirects to Wristband to initialize
+    /// the login flow. If using tenant subdomains, this value must contain the `{tenant_domain}` token.
+    /// </summary>
+    [JsonPropertyName("loginUrl")]
+    public string LoginUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the domain suffix used when constructing login URLs with tenant subdomains.
+    /// This value is null when tenant subdomains are not being used.
+    /// </summary>
+    [JsonPropertyName("loginUrlTenantDomainSuffix")]
+    public string? LoginUrlTenantDomainSuffix { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI that Wristband will redirect to after authenticating a user.
+    /// This should point to your application's callback endpoint.
+    /// If using tenant subdomains, this value must contain the `{tenant_domain}` token.
+    /// </summary>
+    [JsonPropertyName("redirectUri")]
+    public string RedirectUri { get; set; } = string.Empty;
+}

--- a/src/types-and-dtos/public/LoginConfig.cs
+++ b/src/types-and-dtos/public/LoginConfig.cs
@@ -18,11 +18,17 @@ public class LoginConfig
     /// <param name="customState">Custom state data for the login request.</param>
     /// <param name="defaultTenantCustomDomain">An optional default tenant custom domain to use for the login request.</param>
     /// <param name="defaultTenantDomainName">An optional default tenant domain name to use for the login request.</param>
-    public LoginConfig(Dictionary<string, object>? customState, string? defaultTenantCustomDomain, string? defaultTenantDomainName)
+    /// <param name="returnUrl">The URL to return to after authentication is completed.</param>
+    public LoginConfig(
+        Dictionary<string, object>? customState,
+        string? defaultTenantCustomDomain,
+        string? defaultTenantDomainName,
+        string? returnUrl)
     {
         CustomState = customState;
         DefaultTenantCustomDomain = defaultTenantCustomDomain;
         DefaultTenantDomainName = defaultTenantDomainName;
+        ReturnUrl = returnUrl;
     }
 
     /// <summary>
@@ -39,4 +45,9 @@ public class LoginConfig
     /// Gets or sets the optional default tenant domain name to use for the login request.
     /// </summary>
     public string? DefaultTenantDomainName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URL to return to after authentication is completed. If a value is provided, then it takes precedence over the "return_url" request query parameter.
+    /// </summary>
+    public string? ReturnUrl { get; set; }
 }

--- a/src/types-and-dtos/public/LogoutConfig.cs
+++ b/src/types-and-dtos/public/LogoutConfig.cs
@@ -17,12 +17,19 @@ public class LogoutConfig
     /// </summary>
     /// <param name="redirectUrl">Optional URL that the logout endpoint will redirect to after completing the logout operation.</param>
     /// <param name="refreshToken">The refresh token to revoke during logout.</param>
+    /// <param name="state">Optional value that will be appended as a query parameter to the resolved redirect URL.</param>
     /// <param name="tenantCustomDomain">The tenant custom domain for the tenant the user belongs to.</param>
     /// <param name="tenantDomainName">The domain name of the tenant the user belongs to.</param>
-    public LogoutConfig(string? redirectUrl, string? refreshToken, string? tenantCustomDomain, string? tenantDomainName)
+    public LogoutConfig(
+        string? redirectUrl,
+        string? refreshToken,
+        string? state,
+        string? tenantCustomDomain,
+        string? tenantDomainName)
     {
         RedirectUrl = redirectUrl;
         RefreshToken = refreshToken;
+        State = state;
         TenantCustomDomain = tenantCustomDomain;
         TenantDomainName = tenantDomainName;
     }
@@ -36,6 +43,11 @@ public class LogoutConfig
     /// Gets or sets the refresh token to revoke during logout.
     /// </summary>
     public string? RefreshToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional value that will be appended as a query parameter to the resolved redirect URL.
+    /// </summary>
+    public string? State { get; set; }
 
     /// <summary>
     /// Gets or sets the tenant custom domain for the tenant that the user belongs to (if applicable).

--- a/src/types-and-dtos/public/WristbandAuthConfig.cs
+++ b/src/types-and-dtos/public/WristbandAuthConfig.cs
@@ -15,18 +15,19 @@ public class WristbandAuthConfig
     /// <summary>
     /// Initializes a new instance of the <see cref="WristbandAuthConfig"/> class with the specified configuration values.
     /// </summary>
+    /// <param name="autoConfigureEnabled">Flag that tells the SDK to automatically set some of the SDK configuration values by calling to Wristband's SDK Auto-Configuration Endpoint.</param>
     /// <param name="clientId">The client ID for the application.</param>
     /// <param name="clientSecret">The client secret for the application.</param>
+    /// <param name="customApplicationLoginPageUrl">Custom application login (tenant discovery) page URL if self-hosting the application login/tenant discovery UI.</param>
+    /// <param name="dangerouslyDisableSecureCookies">If set to true, the "Secure" attribute will not be included in any cookie settings. Should be used only in local development.</param>
+    /// <param name="isApplicationCustomDomainActive">Indicates whether an application-level custom domain is active for the Wristband application.</param>
     /// <param name="loginStateSecret">A secret (32 or more characters in length) used for encryption and decryption of login state cookies.</param>
     /// <param name="loginUrl">The URL for initiating the login request.</param>
     /// <param name="redirectUri">The redirect URI for callback after authentication.</param>
-    /// <param name="wristbandApplicationVanityDomain">The vanity domain of the Wristband application.</param>
-    /// <param name="customApplicationLoginPageUrl">Custom application login (tenant discovery) page URL if self-hosting the application login/tenant discovery UI.</param>
-    /// <param name="dangerouslyDisableSecureCookies">If set to true, the "Secure" attribute will not be included in any cookie settings. Should be used only in local development.</param>
     /// <param name="parseTenantFromRootDomain">The root domain for your application.</param>
     /// <param name="scopes">The scopes required for authentication.</param>
-    /// <param name="isApplicationCustomDomainActive">Indicates whether an application-level custom domain is active for the Wristband application.</param>
     /// <param name="tokenExpirationBuffer">Buffer time (in seconds) to subtract from the access token’s expiration time. This causes the token to be treated as expired before its actual expiration, helping to avoid token expiration during API calls.</param>
+    /// <param name="wristbandApplicationVanityDomain">The vanity domain of the Wristband application.</param>
     public WristbandAuthConfig(
         string? clientId,
         string? clientSecret,
@@ -39,7 +40,8 @@ public class WristbandAuthConfig
         string? parseTenantFromRootDomain,
         List<string>? scopes,
         bool? isApplicationCustomDomainActive,
-        int? tokenExpirationBuffer)
+        int? tokenExpirationBuffer,
+        bool? autoConfigureEnabled = null)
     {
         ClientId = clientId;
         ClientSecret = clientSecret;
@@ -53,7 +55,15 @@ public class WristbandAuthConfig
         Scopes = scopes;
         IsApplicationCustomDomainActive = isApplicationCustomDomainActive;
         TokenExpirationBuffer = tokenExpirationBuffer;
+        AutoConfigureEnabled = autoConfigureEnabled;
     }
+
+    /// <summary>
+    /// Gets or sets whether the SDK should automatically configure some settings by calling the Wristband SDK Auto-Configuration Endpoint.
+    /// Any manually provided configurations will take precedence over the configs returned from the endpoint.
+    /// Auto-configure is enabled by default. When disabled, manual configurations must be provided, or an error will be thrown.
+    /// </summary>
+    public bool? AutoConfigureEnabled { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the client ID for the application.
@@ -78,7 +88,7 @@ public class WristbandAuthConfig
     /// <summary>
     /// Gets or sets whether an application-level custom domain is active for the Wristband application.
     /// </summary>
-    public bool? IsApplicationCustomDomainActive { get; set; } = false;
+    public bool? IsApplicationCustomDomainActive { get; set; }
 
     /// <summary>
     /// Gets or sets the secret used for encryption and decryption of login state cookies. It should be 32 or more characters long.

--- a/tests/ConfigResolverTests.cs
+++ b/tests/ConfigResolverTests.cs
@@ -1,0 +1,1435 @@
+using Moq;
+
+namespace Wristband.AspNet.Auth.Tests;
+
+public class ConfigResolverTests
+{
+    private readonly Mock<IWristbandApiClient> _mockApiClient;
+    private readonly WristbandAuthConfig _validConfig;
+
+    public ConfigResolverTests()
+    {
+        _mockApiClient = new Mock<IWristbandApiClient>();
+        _validConfig = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = true
+        };
+    }
+
+    // ////////////////////////////////////
+    //  CONSTRUCTOR VALIDATION TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public void Constructor_WithValidConfig_CreatesInstance()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void Constructor_WithNullAuthConfig_ThrowsArgumentNullException()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        var exception = Assert.Throws<ArgumentNullException>(() => new ConfigResolver(null, _mockApiClient.Object));
+
+        Assert.Equal("authConfig", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithNullApiClient_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(
+            () => new ConfigResolver(_validConfig, null));
+
+        Assert.Equal("wristbandApiClient", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "test-client-secret", "test.wristband.dev", "The [ClientId] config must have a value.")]
+    [InlineData("", "test-client-secret", "test.wristband.dev", "The [ClientId] config must have a value.")]
+    [InlineData("  ", "test-client-secret", "test.wristband.dev", "The [ClientId] config must have a value.")]
+    [InlineData("test-client-id", null, "test.wristband.dev", "The [ClientSecret] config must have a value.")]
+    [InlineData("test-client-id", "", "test.wristband.dev", "The [ClientSecret] config must have a value.")]
+    [InlineData("test-client-id", "  ", "test.wristband.dev", "The [ClientSecret] config must have a value.")]
+    [InlineData("test-client-id", "test-client-secret", null, "The [WristbandApplicationVanityDomain] config must have a value.")]
+    [InlineData("test-client-id", "test-client-secret", "", "The [WristbandApplicationVanityDomain] config must have a value.")]
+    [InlineData("test-client-id", "test-client-secret", "  ", "The [WristbandApplicationVanityDomain] config must have a value.")]
+    public void Constructor_WithInvalidRequiredConfigs_ThrowsArgumentException(
+        string clientId, string clientSecret, string domain, string expectedMessage)
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            WristbandApplicationVanityDomain = domain,
+            AutoConfigureEnabled = true
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithShortLoginStateSecret_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginStateSecret = "short", // Less than 32 characters
+            AutoConfigureEnabled = true
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Equal("The [LoginStateSecret] config must have a value of at least 32 characters.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithValidLoginStateSecret_DoesNotThrow()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginStateSecret = "this-is-a-32-character-secret123", // Exactly 32 characters
+            AutoConfigureEnabled = true
+        };
+
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+        Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void Constructor_WithNullLoginStateSecret_DoesNotThrow()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginStateSecret = null,
+            AutoConfigureEnabled = true
+        };
+
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+        Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeTokenExpirationBuffer_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            TokenExpirationBuffer = -1,
+            AutoConfigureEnabled = true
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Equal("The [TokenExpirationBuffer] config must be greater than or equal to 0.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithZeroTokenExpirationBuffer_DoesNotThrow()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            TokenExpirationBuffer = 0,
+            AutoConfigureEnabled = true
+        };
+
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+        Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void Constructor_WithAutoConfigureFalseAndMissingLoginUrl_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            RedirectUri = "https://app.example.com/callback"
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Equal("The [LoginUrl] config must have a value when auto-configure is disabled.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithAutoConfigureFalseAndMissingRedirectUri_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://app.example.com/login"
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Equal("The [RedirectUri] config must have a value when auto-configure is disabled.", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithRootDomainButNoTokenInLoginUrl_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://app.example.com/login", // Missing {tenant_domain} token
+            RedirectUri = "https://{tenant_domain}.example.com/callback",
+            ParseTenantFromRootDomain = "example.com"
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithRootDomainButNoTokenInRedirectUri_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://{tenant_domain}.example.com/login",
+            RedirectUri = "https://app.example.com/callback", // Missing {tenant_domain} token
+            ParseTenantFromRootDomain = "example.com"
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithTokenButNoRootDomainInLoginUrl_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://{tenant_domain}.example.com/login",
+            RedirectUri = "https://app.example.com/callback"
+            // Missing ParseTenantFromRootDomain
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Contains("cannot contain the \"{tenant_domain}\" token", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithTokenButNoRootDomainInRedirectUri_ThrowsArgumentException()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://app.example.com/login",
+            RedirectUri = "https://{tenant_domain}.example.com/callback"
+            // Missing ParseTenantFromRootDomain
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Contains("cannot contain the \"{tenant_domain}\" token", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithPartialUrlConfigsAndAutoConfigureEnabled_ValidatesTokens()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = true,
+            LoginUrl = "https://test.com/login", // No token
+            ParseTenantFromRootDomain = "test.com" // But parsing enabled
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => new ConfigResolver(config, _mockApiClient.Object));
+
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithValidTenantConfiguration_Succeeds()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://{tenant_domain}.test.com/login",
+            RedirectUri = "https://{tenant_domain}.test.com/callback",
+            ParseTenantFromRootDomain = "test.com",
+            LoginStateSecret = "this-is-a-32-character-secret123"
+        };
+
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+        Assert.NotNull(resolver);
+    }
+
+    // ////////////////////////////////////
+    //  SIMPLE GETTER TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public void GetClientId_ReturnsConfigValue()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetClientId();
+
+        Assert.Equal("test-client-id", result);
+    }
+
+    [Fact]
+    public void GetClientSecret_ReturnsConfigValue()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetClientSecret();
+
+        Assert.Equal("test-client-secret", result);
+    }
+
+    [Fact]
+    public void GetLoginStateSecret_WithoutValue_ReturnsClientSecret()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetLoginStateSecret();
+
+        Assert.Equal("test-client-secret", result);
+    }
+
+    [Fact]
+    public void GetLoginStateSecret_WithValue_ReturnsConfigValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginStateSecret = "custom-login-state-secret-32-chars",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetLoginStateSecret();
+
+        Assert.Equal("custom-login-state-secret-32-chars", result);
+    }
+
+    [Fact]
+    public void GetWristbandApplicationVanityDomain_ReturnsConfigValue()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetWristbandApplicationVanityDomain();
+
+        Assert.Equal("test.wristband.dev", result);
+    }
+
+    [Fact]
+    public void GetDangerouslyDisableSecureCookies_WithoutValue_ReturnsFalse()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetDangerouslyDisableSecureCookies();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetDangerouslyDisableSecureCookies_WithValue_ReturnsConfigValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            DangerouslyDisableSecureCookies = true,
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetDangerouslyDisableSecureCookies();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void GetScopes_WithoutValue_ReturnsDefaultScopes()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetScopes();
+
+        Assert.Equal(new List<string> { "openid", "offline_access", "email" }, result);
+    }
+
+    [Fact]
+    public void GetScopes_WithValue_ReturnsConfigValue()
+    {
+        var customScopes = new List<string> { "openid", "profile", "custom" };
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            Scopes = customScopes,
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetScopes();
+
+        Assert.Equal(customScopes, result);
+    }
+
+    [Fact]
+    public void GetScopes_WithEmptyList_ReturnsDefaultScopes()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            Scopes = new List<string>(),
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetScopes();
+
+        Assert.Equal(new List<string> { "openid", "offline_access", "email" }, result);
+    }
+
+    [Fact]
+    public void GetAutoConfigureEnabled_WithoutValue_ReturnsTrue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = null
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetAutoConfigureEnabled();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void GetAutoConfigureEnabled_WithValue_ReturnsConfigValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetAutoConfigureEnabled();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetTokenExpirationBuffer_WithoutValue_ReturnsDefault()
+    {
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = resolver.GetTokenExpirationBuffer();
+
+        Assert.Equal(60, result);
+    }
+
+    [Fact]
+    public void GetTokenExpirationBuffer_WithValue_ReturnsConfigValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            TokenExpirationBuffer = 120,
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = resolver.GetTokenExpirationBuffer();
+
+        Assert.Equal(120, result);
+    }
+
+    // ////////////////////////////////////
+    //  ASYNC GETTER TESTS - MANUAL CONFIG PRECEDENCE
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task GetCustomApplicationLoginPageUrl_WithManualConfig_ReturnsManualValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            CustomApplicationLoginPageUrl = "https://manual.com/custom",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetCustomApplicationLoginPageUrl();
+
+        Assert.Equal("https://manual.com/custom", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetIsApplicationCustomDomainActive_WithManualConfig_ReturnsManualValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            IsApplicationCustomDomainActive = true,
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetIsApplicationCustomDomainActive();
+
+        Assert.True(result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetLoginUrl_WithManualConfig_ReturnsManualValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginUrl = "https://manual-login.example.com",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetLoginUrl();
+
+        Assert.Equal("https://manual-login.example.com", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetRedirectUri_WithManualConfig_ReturnsManualValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            RedirectUri = "https://manual-callback.example.com",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetRedirectUri();
+
+        Assert.Equal("https://manual-callback.example.com", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetParseTenantFromRootDomain_WithManualConfig_ReturnsManualValue()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            ParseTenantFromRootDomain = "manual.example.com",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetParseTenantFromRootDomain();
+
+        Assert.Equal("manual.example.com", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    // ////////////////////////////////////
+    //  ASYNC GETTER TESTS - AUTO CONFIG FALLBACK
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task GetCustomApplicationLoginPageUrl_WithAutoConfigureAndSdkValue_ReturnsSdkValue()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            CustomApplicationLoginPageUrl = "https://sdk-login.example.com",
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetCustomApplicationLoginPageUrl();
+
+        Assert.Equal("https://sdk-login.example.com", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCustomApplicationLoginPageUrl_WithAutoConfigureAndNoSdkValue_ReturnsEmptyString()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            CustomApplicationLoginPageUrl = null,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetCustomApplicationLoginPageUrl();
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetIsApplicationCustomDomainActive_WithAutoConfigureAndSdkValue_ReturnsSdkValue()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            IsApplicationCustomDomainActive = true,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetIsApplicationCustomDomainActive();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task GetLoginUrl_WithAutoConfigureAndSdkValue_ReturnsSdkValue()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk-login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetLoginUrl();
+
+        Assert.Equal("https://sdk-login.example.com", result);
+    }
+
+    [Fact]
+    public async Task GetRedirectUri_WithAutoConfigureAndSdkValue_ReturnsSdkValue()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://sdk-callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetRedirectUri();
+
+        Assert.Equal("https://sdk-callback.example.com", result);
+    }
+
+    [Fact]
+    public async Task GetParseTenantFromRootDomain_WithAutoConfigureAndSdkValue_ReturnsSdkValue()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://{tenant_domain}.sdk.example.com/login",
+            RedirectUri = "https://{tenant_domain}.sdk.example.com/callback",
+            LoginUrlTenantDomainSuffix = "sdk.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetParseTenantFromRootDomain();
+
+        Assert.Equal("sdk.example.com", result);
+    }
+
+    [Fact]
+    public async Task GetParseTenantFromRootDomain_WithAutoConfigureAndNoSdkValue_ReturnsEmptyString()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com",
+            LoginUrlTenantDomainSuffix = null
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetParseTenantFromRootDomain();
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    // ////////////////////////////////////
+    //  AUTO CONFIG DISABLED FALLBACK TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task GetCustomApplicationLoginPageUrl_WithAutoConfigureDisabled_ReturnsEmptyString()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetCustomApplicationLoginPageUrl();
+
+        Assert.Equal(string.Empty, result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetIsApplicationCustomDomainActive_WithAutoConfigureDisabled_ReturnsFalse()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetIsApplicationCustomDomainActive();
+
+        Assert.False(result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetParseTenantFromRootDomain_WithAutoConfigureDisabled_ReturnsEmptyString()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetParseTenantFromRootDomain();
+
+        Assert.Equal(string.Empty, result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    // ////////////////////////////////////
+    //  PRELOAD CONFIG TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task PreloadConfig_WithAutoConfigureEnabled_LoadsConfiguration()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        await resolver.PreloadConfig();
+
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task PreloadConfig_WithAutoConfigureDisabled_ThrowsWristbandError()
+    {
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = false,
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.PreloadConfig());
+
+        Assert.Equal("config_error", exception.Error);
+        Assert.Contains("Cannot preload configs when AutoConfigureEnabled is false", exception.ErrorDescription);
+    }
+
+    // ////////////////////////////////////
+    //  SDK CONFIGURATION CACHING TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task SdkConfigurationCaching_MultipleCallsOnlyFetchOnce()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com",
+            CustomApplicationLoginPageUrl = "https://custom.example.com",
+            IsApplicationCustomDomainActive = true
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        // Create config without IsApplicationCustomDomainActive set
+        var testConfig = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            AutoConfigureEnabled = true
+            // Don't set IsApplicationCustomDomainActive - let it use SDK config
+        };
+        var resolver = new ConfigResolver(testConfig, _mockApiClient.Object);
+
+        // Multiple calls to different getters
+        var loginUrl = await resolver.GetLoginUrl();
+        var redirectUri = await resolver.GetRedirectUri();
+        var customUrl = await resolver.GetCustomApplicationLoginPageUrl();
+        var customDomain = await resolver.GetIsApplicationCustomDomainActive();
+
+        Assert.Equal("https://login.example.com", loginUrl);
+        Assert.Equal("https://callback.example.com", redirectUri);
+        Assert.Equal("https://custom.example.com", customUrl);
+        Assert.True(customDomain);
+
+        // Should only have called the API once due to caching
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Once);
+    }
+
+    // ////////////////////////////////////
+    //  SDK CONFIGURATION VALIDATION TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task GetLoginUrl_WithSdkConfigMissingLoginUrl_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "", // Missing required field
+            RedirectUri = "https://callback.example.com"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("SDK configuration response missing required field: LoginUrl", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task GetRedirectUri_WithSdkConfigMissingRedirectUri_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "" // Missing required field
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetRedirectUri());
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("SDK configuration response missing required field: RedirectUri", exception.ErrorDescription);
+    }
+
+    // ////////////////////////////////////
+    //  SDK CONFIGURATION RETRY TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task SdkConfigurationFetch_WithRetrySuccess_ReturnsConfiguration()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+
+        _mockApiClient.SetupSequence(x => x.GetSdkConfiguration())
+            .ThrowsAsync(new Exception("Network error 1"))
+            .ThrowsAsync(new Exception("Network error 2"))
+            .ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var result = await resolver.GetLoginUrl();
+
+        Assert.Equal("https://login.example.com", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task SdkConfigurationFetch_WithMaxRetriesExceeded_ThrowsWristbandError()
+    {
+        _mockApiClient.Setup(x => x.GetSdkConfiguration())
+            .ThrowsAsync(new Exception("Persistent network error"));
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("Failed to fetch SDK configuration after 3 attempts", exception.ErrorDescription);
+        Assert.Contains("Persistent network error", exception.ErrorDescription);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Exactly(3));
+    }
+
+    // ////////////////////////////////////
+    //  DYNAMIC CONFIGURATION VALIDATION TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task DynamicValidation_WithTenantDomainButNoTokenInResolvedLoginUrl_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login", // No tenant token
+            RedirectUri = "https://sdk.example.com/callback"
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            ParseTenantFromRootDomain = "test.com", // Tenant parsing enabled
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Equal("config_validation_error", exception.Error);
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task DynamicValidation_WithTenantDomainButNoTokenInResolvedRedirectUri_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://{tenant_domain}.sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback" // No tenant token
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            ParseTenantFromRootDomain = "test.com", // Tenant parsing enabled
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetRedirectUri());
+
+        Assert.Equal("config_validation_error", exception.Error);
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task DynamicValidation_WithTokenButNoTenantParsingInResolvedLoginUrl_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://{tenant_domain}.sdk.example.com/login", // Has tenant token
+            RedirectUri = "https://sdk.example.com/callback",
+            LoginUrlTenantDomainSuffix = null // No tenant parsing
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Equal("config_validation_error", exception.Error);
+        Assert.Contains("cannot contain the \"{tenant_domain}\" token", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task DynamicValidation_WithTokenButNoTenantParsingInResolvedRedirectUri_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://{tenant_domain}.sdk.example.com/callback", // Has tenant token
+            LoginUrlTenantDomainSuffix = null // No tenant parsing
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetRedirectUri());
+
+        Assert.Equal("config_validation_error", exception.Error);
+        Assert.Contains("cannot contain the \"{tenant_domain}\" token", exception.ErrorDescription);
+    }
+
+    // ////////////////////////////////////
+    //  EDGE CASES AND INTEGRATION TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task MixedManualAndAutoConfig_UsesCorrectPrecedence()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback",
+            CustomApplicationLoginPageUrl = null,
+            IsApplicationCustomDomainActive = false,
+            LoginUrlTenantDomainSuffix = null
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginUrl = "https://manual.example.com/login", // Manual override
+            // RedirectUri will come from auto-config
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var loginUrl = await resolver.GetLoginUrl();
+        var redirectUri = await resolver.GetRedirectUri();
+        var customUrl = await resolver.GetCustomApplicationLoginPageUrl();
+
+        Assert.Equal("https://manual.example.com/login", loginUrl); // Manual
+        Assert.Equal("https://sdk.example.com/callback", redirectUri); // Auto-config
+        Assert.Equal(string.Empty, customUrl); // Auto-config empty
+
+        // Should only call SDK once despite multiple getters
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task BooleanHandling_ForIsApplicationCustomDomainActive_HandlesAllCases()
+    {
+        // Test explicit False
+        var config1 = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            IsApplicationCustomDomainActive = false,
+            AutoConfigureEnabled = true
+        };
+        var resolver1 = new ConfigResolver(config1, _mockApiClient.Object);
+        var result1 = await resolver1.GetIsApplicationCustomDomainActive();
+        Assert.False(result1);
+
+        // Test explicit True
+        var config2 = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            IsApplicationCustomDomainActive = true,
+            AutoConfigureEnabled = true
+        };
+        var resolver2 = new ConfigResolver(config2, _mockApiClient.Object);
+        var result2 = await resolver2.GetIsApplicationCustomDomainActive();
+        Assert.True(result2);
+
+        // Test null with auto-config
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback",
+            IsApplicationCustomDomainActive = false
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config3 = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            IsApplicationCustomDomainActive = null,
+            AutoConfigureEnabled = true
+        };
+        var resolver3 = new ConfigResolver(config3, _mockApiClient.Object);
+        var result3 = await resolver3.GetIsApplicationCustomDomainActive();
+        Assert.False(result3);
+    }
+
+    [Fact]
+    public async Task EmptyStringValues_AreHandledCorrectly()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback",
+            CustomApplicationLoginPageUrl = null,
+            IsApplicationCustomDomainActive = true
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            CustomApplicationLoginPageUrl = "",
+            ParseTenantFromRootDomain = "",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var customUrl = await resolver.GetCustomApplicationLoginPageUrl();
+        var parseTenant = await resolver.GetParseTenantFromRootDomain();
+
+        Assert.Equal("", customUrl);
+        Assert.Equal("", parseTenant);
+    }
+
+    [Fact]
+    public async Task ManualConfigTakesPrecedenceInValidation()
+    {
+        // Manual config has correct tenant domain token
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            LoginUrl = "https://{tenant_domain}.manual.com/login",
+            ParseTenantFromRootDomain = "manual.com",
+            AutoConfigureEnabled = true
+        };
+
+        // SDK config would fail validation if used
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login", // No tenant token
+            RedirectUri = "https://{tenant_domain}.sdk.com/callback",
+            IsApplicationCustomDomainActive = true
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        // Should not raise validation error because manual login_url is used
+        var result = await resolver.GetLoginUrl();
+        Assert.Equal("https://{tenant_domain}.manual.com/login", result);
+    }
+
+    [Fact]
+    public async Task ErrorPreservesOriginalMessage()
+    {
+        var originalError = new Exception("Network connection failed");
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ThrowsAsync(originalError);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Contains("Network connection failed", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task ErrorAllowsRetryAfterFailure()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback"
+        };
+
+        _mockApiClient.SetupSequence(x => x.GetSdkConfiguration())
+            .ThrowsAsync(new Exception("First error"))
+            .ThrowsAsync(new Exception("Second error"))
+            .ThrowsAsync(new Exception("Third error"))
+            .ReturnsAsync(sdkConfig); // Success on retry
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        // First attempt should fail after 3 retries
+        var firstException = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+        Assert.Contains("Failed to fetch SDK configuration after 3 attempts", firstException.ErrorDescription);
+
+        // Second attempt should succeed (new cache attempt)
+        var result = await resolver.GetRedirectUri();
+        Assert.Equal("https://sdk.example.com/callback", result);
+
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Exactly(4));
+    }
+
+    [Fact]
+    public async Task DynamicValidation_WithSdkSuffix_EnablesTenantParsing()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login", // No token
+            RedirectUri = "https://sdk.example.com/callback", // No token
+            LoginUrlTenantDomainSuffix = "sdk.example.com" // This should enable tenant parsing
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        // Should fail because SDK config enables tenant parsing but URLs don't have tokens
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Equal("config_validation_error", exception.Error);
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task DynamicValidation_SdkEnablesTenantParsingButManualUrlHasNoToken()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://manual.example.com/login", // SDK URL without token
+            RedirectUri = "https://{tenant_domain}.sdk.example.com/callback",
+            LoginUrlTenantDomainSuffix = "sdk.example.com" // SDK enables tenant parsing
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            // No manual ParseTenantFromRootDomain - should use SDK's LoginUrlTenantDomainSuffix
+            AutoConfigureEnabled = true
+        };
+
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        // Should fail because SDK LoginUrl has no token but SDK enables parsing via LoginUrlTenantDomainSuffix
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetLoginUrl());
+
+        Assert.Equal("config_validation_error", exception.Error);
+        Assert.Contains("must contain the \"{tenant_domain}\" token", exception.ErrorDescription);
+    }
+
+    // ////////////////////////////////////
+    //  THREAD SAFETY TESTS
+    // ////////////////////////////////////
+
+    [Fact]
+    public async Task ThreadSafety_MultipleThreadsCallGetters_OnlyFetchOnce()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback",
+            CustomApplicationLoginPageUrl = "https://custom.example.com",
+            IsApplicationCustomDomainActive = true
+        };
+
+        _mockApiClient.Setup(x => x.GetSdkConfiguration())
+            .Returns(async () =>
+            {
+                // Add small delay to simulate network request
+                await Task.Delay(50);
+                return sdkConfig;
+            });
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var loginUrlTask = Task.Run(async () => await resolver.GetLoginUrl());
+        var redirectUriTask = Task.Run(async () => await resolver.GetRedirectUri());
+        var customUrlTask = Task.Run(async () => await resolver.GetCustomApplicationLoginPageUrl());
+        var customDomainTask = Task.Run(async () => await resolver.GetIsApplicationCustomDomainActive());
+
+        // Wait for all tasks to complete
+        await Task.WhenAll(loginUrlTask, redirectUriTask, customUrlTask, customDomainTask);
+
+        // Access individual results after completion
+        Assert.Equal("https://sdk.example.com/login", await loginUrlTask);
+        Assert.Equal("https://sdk.example.com/callback", await redirectUriTask);
+        Assert.Equal("https://custom.example.com", await customUrlTask);
+        Assert.True(await customDomainTask);
+
+        // Should only have called the API once due to thread safety and caching
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ThreadSafety_ConcurrentPreloadAndGetRequests_WorksCorrectly()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback",
+            IsApplicationCustomDomainActive = false
+        };
+
+        _mockApiClient.Setup(x => x.GetSdkConfiguration())
+            .Returns(async () =>
+            {
+                await Task.Delay(100); // Simulate network delay
+                return sdkConfig;
+            });
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var tasks = new List<Task>
+        {
+            Task.Run(async () => await resolver.PreloadConfig()),
+            Task.Run(async () => await resolver.GetLoginUrl()),
+            Task.Run(async () => await resolver.GetRedirectUri()),
+            Task.Run(async () => await resolver.GetIsApplicationCustomDomainActive())
+        };
+
+        await Task.WhenAll(tasks);
+
+        // Should only make one API call despite multiple concurrent requests
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ThreadSafety_ErrorRecoveryAcrossThreads_WorksCorrectly()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://sdk.example.com/login",
+            RedirectUri = "https://sdk.example.com/callback"
+        };
+
+        var callCount = 0;
+        _mockApiClient.Setup(x => x.GetSdkConfiguration())
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount <= 3)
+                {
+                    throw new Exception($"Error {callCount}");
+                }
+                return Task.FromResult(sdkConfig);
+            });
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        // First attempt should fail after retries
+        await Assert.ThrowsAsync<WristbandError>(() => resolver.GetLoginUrl());
+        Assert.Equal(3, callCount);
+
+        // Concurrent requests after failure should succeed
+        var loginUrlTask = Task.Run(async () => await resolver.GetLoginUrl());
+        var redirectUriTask = Task.Run(async () => await resolver.GetRedirectUri());
+
+        var results = await Task.WhenAll(loginUrlTask, redirectUriTask);
+
+        Assert.Equal("https://sdk.example.com/login", results[0]);
+        Assert.Equal("https://sdk.example.com/callback", results[1]);
+        Assert.Equal(4, callCount); // One more successful call
+    }
+}

--- a/tests/extensions/WristbandAuthServiceExtensionsTests.cs
+++ b/tests/extensions/WristbandAuthServiceExtensionsTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -8,58 +7,6 @@ namespace Wristband.AspNet.Auth.Tests;
 
 public class WristbandServiceExtensionsTests
 {
-    [Fact]
-    public void AddWristbandAuth_WithConfiguration_RegistersServices()
-    {
-        var services = new ServiceCollection();
-        services.AddOptions();
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                {"WristbandAuthConfig:ClientId", "test-client"},
-                {"WristbandAuthConfig:ClientSecret", "test-secret"},
-                {"WristbandAuthConfig:LoginStateSecret", "this-is-a-secret-that-is-at-least-32-chars"},
-                {"WristbandAuthConfig:LoginUrl", "https://login.url"},
-                {"WristbandAuthConfig:RedirectUri", "https://redirect.uri"},
-                {"WristbandAuthConfig:WristbandApplicationVanityDomain", "wristband.domain"}
-            })
-            .Build();
-
-        services.AddWristbandAuth(configuration);
-
-        var serviceProvider = services.BuildServiceProvider();
-        var authConfig = serviceProvider.GetService<IOptions<WristbandAuthConfig>>();
-        Assert.NotNull(authConfig);
-        Assert.Equal("test-client", authConfig.Value.ClientId);
-        Assert.Equal("test-secret", authConfig.Value.ClientSecret);
-    }
-
-    [Fact]
-    public void AddWristbandAuth_WithConfiguration_CustomSectionName_RegistersServices()
-    {
-        var services = new ServiceCollection();
-        services.AddOptions();
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                {"CustomSection:ClientId", "test-client"},
-                {"CustomSection:ClientSecret", "test-secret"},
-                {"CustomSection:LoginStateSecret", "this-is-a-secret-that-is-at-least-32-chars"},
-                {"CustomSection:LoginUrl", "https://login.url"},
-                {"CustomSection:RedirectUri", "https://redirect.uri"},
-                {"CustomSection:WristbandApplicationVanityDomain", "wristband.domain"}
-            })
-            .Build();
-
-        services.AddWristbandAuth(configuration, "CustomSection");
-
-        var serviceProvider = services.BuildServiceProvider();
-        var authConfig = serviceProvider.GetService<IOptions<WristbandAuthConfig>>();
-        Assert.NotNull(authConfig);
-        Assert.Equal("test-client", authConfig.Value.ClientId);
-        Assert.Equal("test-secret", authConfig.Value.ClientSecret);
-    }
-
     [Fact]
     public void AddWristbandAuth_WithDirectConfiguration_RegistersServices()
     {
@@ -271,7 +218,7 @@ public class WristbandServiceExtensionsTests
 
         var registration = services.FirstOrDefault(sd => sd.ServiceType == typeof(IWristbandAuthService));
         Assert.NotNull(registration);
-        Assert.Equal(ServiceLifetime.Scoped, registration.Lifetime);
+        Assert.Equal(ServiceLifetime.Singleton, registration.Lifetime);
     }
 
     [Fact]
@@ -330,37 +277,6 @@ public class WristbandServiceExtensionsTests
             "auth01",
             options => { }
         ));
-        Assert.Equal("services", exception.ParamName);
-    }
-
-    // Existing null check tests
-    [Fact]
-    public void AddWristbandAuth_WithNullConfiguration_ThrowsArgumentNullException()
-    {
-        var services = new ServiceCollection();
-        IConfiguration configuration = null!;
-
-        var exception = Assert.Throws<ArgumentNullException>(() => services.AddWristbandAuth(configuration));
-        Assert.Equal("configuration", exception.ParamName);
-    }
-
-    [Fact]
-    public void AddWristbandAuth_WithNullConfigureOptions_ThrowsArgumentNullException()
-    {
-        var services = new ServiceCollection();
-        Action<WristbandAuthConfig> configureOptions = null!;
-
-        var exception = Assert.Throws<ArgumentNullException>(() => services.AddWristbandAuth(configureOptions));
-        Assert.Equal("configureOptions", exception.ParamName);
-    }
-
-    [Fact]
-    public void AddWristbandAuth_WithNullServices_ThrowsArgumentNullException()
-    {
-        IServiceCollection services = null!;
-        var configuration = new ConfigurationBuilder().Build();
-
-        var exception = Assert.Throws<ArgumentNullException>(() => services.AddWristbandAuth(configuration));
         Assert.Equal("services", exception.ParamName);
     }
 }

--- a/tests/types-and-dtos/internal/SdkConfigurationTests.cs
+++ b/tests/types-and-dtos/internal/SdkConfigurationTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+
+namespace Wristband.AspNet.Auth.Tests;
+
+public class SdkConfigurationTests
+{
+    [Fact]
+    public void DefaultConstructor_ShouldInitializePropertiesWithDefaults()
+    {
+        var config = new SdkConfiguration();
+
+        Assert.Null(config.CustomApplicationLoginPageUrl);
+        Assert.False(config.IsApplicationCustomDomainActive);
+        Assert.Equal(string.Empty, config.LoginUrl);
+        Assert.Null(config.LoginUrlTenantDomainSuffix);
+        Assert.Equal(string.Empty, config.RedirectUri);
+    }
+
+    [Fact]
+    public void CustomApplicationLoginPageUrl_ShouldBeSettableAfterConstruction()
+    {
+        var config = new SdkConfiguration();
+        var url = "https://custom-login.example.com";
+
+        config.CustomApplicationLoginPageUrl = url;
+
+        Assert.Equal(url, config.CustomApplicationLoginPageUrl);
+    }
+
+    [Fact]
+    public void CustomApplicationLoginPageUrl_ShouldAcceptNull()
+    {
+        var config = new SdkConfiguration();
+
+        config.CustomApplicationLoginPageUrl = null;
+
+        Assert.Null(config.CustomApplicationLoginPageUrl);
+    }
+
+    [Fact]
+    public void IsApplicationCustomDomainActive_ShouldBeSettableAfterConstruction()
+    {
+        var config = new SdkConfiguration();
+
+        config.IsApplicationCustomDomainActive = true;
+
+        Assert.True(config.IsApplicationCustomDomainActive);
+    }
+
+    [Fact]
+    public void IsApplicationCustomDomainActive_ShouldDefaultToFalse()
+    {
+        var config = new SdkConfiguration();
+
+        Assert.False(config.IsApplicationCustomDomainActive);
+    }
+
+    [Fact]
+    public void LoginUrl_ShouldBeSettableAfterConstruction()
+    {
+        var config = new SdkConfiguration();
+        var loginUrl = "https://myapp.com/login";
+
+        config.LoginUrl = loginUrl;
+
+        Assert.Equal(loginUrl, config.LoginUrl);
+    }
+
+    [Fact]
+    public void LoginUrl_ShouldDefaultToEmptyString()
+    {
+        var config = new SdkConfiguration();
+
+        Assert.Equal(string.Empty, config.LoginUrl);
+    }
+
+    [Fact]
+    public void LoginUrl_ShouldAcceptTenantDomainToken()
+    {
+        var config = new SdkConfiguration();
+        var loginUrl = "https://{tenant_domain}.myapp.com/login";
+
+        config.LoginUrl = loginUrl;
+
+        Assert.Equal(loginUrl, config.LoginUrl);
+    }
+
+    [Fact]
+    public void LoginUrlTenantDomainSuffix_ShouldBeSettableAfterConstruction()
+    {
+        var config = new SdkConfiguration();
+        var suffix = ".myapp.com";
+
+        config.LoginUrlTenantDomainSuffix = suffix;
+
+        Assert.Equal(suffix, config.LoginUrlTenantDomainSuffix);
+    }
+
+    [Fact]
+    public void LoginUrlTenantDomainSuffix_ShouldAcceptNull()
+    {
+        var config = new SdkConfiguration();
+
+        config.LoginUrlTenantDomainSuffix = null;
+
+        Assert.Null(config.LoginUrlTenantDomainSuffix);
+    }
+
+    [Fact]
+    public void RedirectUri_ShouldBeSettableAfterConstruction()
+    {
+        var config = new SdkConfiguration();
+        var redirectUri = "https://myapp.com/callback";
+
+        config.RedirectUri = redirectUri;
+
+        Assert.Equal(redirectUri, config.RedirectUri);
+    }
+
+    [Fact]
+    public void RedirectUri_ShouldDefaultToEmptyString()
+    {
+        var config = new SdkConfiguration();
+
+        Assert.Equal(string.Empty, config.RedirectUri);
+    }
+
+    [Fact]
+    public void RedirectUri_ShouldAcceptTenantDomainToken()
+    {
+        var config = new SdkConfiguration();
+        var redirectUri = "https://{tenant_domain}.myapp.com/callback";
+
+        config.RedirectUri = redirectUri;
+
+        Assert.Equal(redirectUri, config.RedirectUri);
+    }
+
+    [Fact]
+    public void JsonSerialization_ShouldUseCorrectPropertyNames()
+    {
+        var config = new SdkConfiguration
+        {
+            CustomApplicationLoginPageUrl = "https://custom.example.com",
+            IsApplicationCustomDomainActive = true,
+            LoginUrl = "https://login.example.com",
+            LoginUrlTenantDomainSuffix = ".example.com",
+            RedirectUri = "https://callback.example.com"
+        };
+
+        var json = JsonSerializer.Serialize(config);
+
+        Assert.Contains("\"customApplicationLoginPageUrl\":", json);
+        Assert.Contains("\"isApplicationCustomDomainActive\":", json);
+        Assert.Contains("\"loginUrl\":", json);
+        Assert.Contains("\"loginUrlTenantDomainSuffix\":", json);
+        Assert.Contains("\"redirectUri\":", json);
+    }
+
+    [Fact]
+    public void JsonDeserialization_ShouldMapPropertiesCorrectly()
+    {
+        var json = @"{
+            ""customApplicationLoginPageUrl"": ""https://custom.example.com"",
+            ""isApplicationCustomDomainActive"": true,
+            ""loginUrl"": ""https://login.example.com"",
+            ""loginUrlTenantDomainSuffix"": "".example.com"",
+            ""redirectUri"": ""https://callback.example.com""
+        }";
+
+        var config = JsonSerializer.Deserialize<SdkConfiguration>(json);
+
+        Assert.NotNull(config);
+        Assert.Equal("https://custom.example.com", config.CustomApplicationLoginPageUrl);
+        Assert.True(config.IsApplicationCustomDomainActive);
+        Assert.Equal("https://login.example.com", config.LoginUrl);
+        Assert.Equal(".example.com", config.LoginUrlTenantDomainSuffix);
+        Assert.Equal("https://callback.example.com", config.RedirectUri);
+    }
+
+    [Fact]
+    public void JsonDeserialization_WithNullValues_ShouldHandleCorrectly()
+    {
+        var json = @"{
+            ""customApplicationLoginPageUrl"": null,
+            ""isApplicationCustomDomainActive"": false,
+            ""loginUrl"": """",
+            ""loginUrlTenantDomainSuffix"": null,
+            ""redirectUri"": """"
+        }";
+
+        var config = JsonSerializer.Deserialize<SdkConfiguration>(json);
+
+        Assert.NotNull(config);
+        Assert.Null(config.CustomApplicationLoginPageUrl);
+        Assert.False(config.IsApplicationCustomDomainActive);
+        Assert.Equal(string.Empty, config.LoginUrl);
+        Assert.Null(config.LoginUrlTenantDomainSuffix);
+        Assert.Equal(string.Empty, config.RedirectUri);
+    }
+}

--- a/tests/types-and-dtos/public/LoginConfigTests.cs
+++ b/tests/types-and-dtos/public/LoginConfigTests.cs
@@ -10,6 +10,7 @@ namespace Wristband.AspNet.Auth.Tests
             Assert.Null(config.CustomState);
             Assert.Null(config.DefaultTenantCustomDomain);
             Assert.Null(config.DefaultTenantDomainName);
+            Assert.Null(config.ReturnUrl);
         }
 
         [Fact]
@@ -18,24 +19,27 @@ namespace Wristband.AspNet.Auth.Tests
             var customState = new Dictionary<string, object> { { "key", "value" } };
             var defaultTenantCustomDomain = "custom.example.com";
             var defaultTenantDomainName = "example.com";
+            var returnUrl = "https://app.example.com/dashboard";
 
-            var config = new LoginConfig(customState, defaultTenantCustomDomain, defaultTenantDomainName);
+            var config = new LoginConfig(customState, defaultTenantCustomDomain, defaultTenantDomainName, returnUrl);
 
             Assert.NotNull(config.CustomState);
             Assert.True(config.CustomState.ContainsKey("key"));
             Assert.Equal("value", config.CustomState["key"]);
             Assert.Equal(defaultTenantCustomDomain, config.DefaultTenantCustomDomain);
             Assert.Equal(defaultTenantDomainName, config.DefaultTenantDomainName);
+            Assert.Equal(returnUrl, config.ReturnUrl);
         }
 
         [Fact]
         public void Constructor_WithNullValues_ShouldSetPropertiesToNull()
         {
-            var config = new LoginConfig(null, null, null);
+            var config = new LoginConfig(null, null, null, null);
 
             Assert.Null(config.CustomState);
             Assert.Null(config.DefaultTenantCustomDomain);
             Assert.Null(config.DefaultTenantDomainName);
+            Assert.Null(config.ReturnUrl);
         }
 
         [Fact]
@@ -47,12 +51,14 @@ namespace Wristband.AspNet.Auth.Tests
             config.CustomState = newCustomState;
             config.DefaultTenantCustomDomain = "updated.example.com";
             config.DefaultTenantDomainName = "updated.com";
+            config.ReturnUrl = "https://updated.example.com/profile";
 
             Assert.NotNull(config.CustomState);
             Assert.True(config.CustomState.ContainsKey("foo"));
             Assert.Equal(42, config.CustomState["foo"]);
             Assert.Equal("updated.example.com", config.DefaultTenantCustomDomain);
             Assert.Equal("updated.com", config.DefaultTenantDomainName);
+            Assert.Equal("https://updated.example.com/profile", config.ReturnUrl);
         }
     }
 }

--- a/tests/types-and-dtos/public/LogoutConfigTests.cs
+++ b/tests/types-and-dtos/public/LogoutConfigTests.cs
@@ -8,15 +8,17 @@ namespace Wristband.AspNet.Auth.Tests
             // Arrange
             var redirectUrl = "https://example.com/logout";
             var refreshToken = "sampleRefreshToken";
+            var state = "customStateValue";
             var tenantCustomDomain = "tenant.custom.domain";
             var tenantDomainName = "tenant.domain.name";
 
             // Act
-            var logoutConfig = new LogoutConfig(redirectUrl, refreshToken, tenantCustomDomain, tenantDomainName);
+            var logoutConfig = new LogoutConfig(redirectUrl, refreshToken, state, tenantCustomDomain, tenantDomainName);
 
             // Assert
             Assert.Equal(redirectUrl, logoutConfig.RedirectUrl);
             Assert.Equal(refreshToken, logoutConfig.RefreshToken);
+            Assert.Equal(state, logoutConfig.State);
             Assert.Equal(tenantCustomDomain, logoutConfig.TenantCustomDomain);
             Assert.Equal(tenantDomainName, logoutConfig.TenantDomainName);
         }
@@ -30,6 +32,7 @@ namespace Wristband.AspNet.Auth.Tests
             // Assert
             Assert.Null(logoutConfig.RedirectUrl);
             Assert.Null(logoutConfig.RefreshToken);
+            Assert.Null(logoutConfig.State);
             Assert.Null(logoutConfig.TenantCustomDomain);
             Assert.Null(logoutConfig.TenantDomainName);
         }
@@ -38,11 +41,12 @@ namespace Wristband.AspNet.Auth.Tests
         public void Constructor_WithNullValues_SetsNullValues()
         {
             // Act
-            var logoutConfig = new LogoutConfig(null, null, null, null);
+            var logoutConfig = new LogoutConfig(null, null, null, null, null);
 
             // Assert
             Assert.Null(logoutConfig.RedirectUrl);
             Assert.Null(logoutConfig.RefreshToken);
+            Assert.Null(logoutConfig.State);
             Assert.Null(logoutConfig.TenantCustomDomain);
             Assert.Null(logoutConfig.TenantDomainName);
         }
@@ -53,17 +57,40 @@ namespace Wristband.AspNet.Auth.Tests
             // Arrange
             var redirectUrl = "https://example.com/logout";
             string? refreshToken = null;
+            var state = "testState";
             var tenantCustomDomain = "tenant.custom.domain";
             string? tenantDomainName = null;
 
             // Act
-            var logoutConfig = new LogoutConfig(redirectUrl, refreshToken, tenantCustomDomain, tenantDomainName);
+            var logoutConfig = new LogoutConfig(redirectUrl, refreshToken, state, tenantCustomDomain, tenantDomainName);
 
             // Assert
             Assert.Equal(redirectUrl, logoutConfig.RedirectUrl);
             Assert.Null(logoutConfig.RefreshToken);
+            Assert.Equal(state, logoutConfig.State);
             Assert.Equal(tenantCustomDomain, logoutConfig.TenantCustomDomain);
             Assert.Null(logoutConfig.TenantDomainName);
+        }
+
+        [Fact]
+        public void Properties_CanBeSetIndividually()
+        {
+            // Arrange
+            var logoutConfig = new LogoutConfig();
+
+            // Act
+            logoutConfig.RedirectUrl = "https://example.com/logout";
+            logoutConfig.RefreshToken = "testToken";
+            logoutConfig.State = "testState";
+            logoutConfig.TenantCustomDomain = "custom.domain";
+            logoutConfig.TenantDomainName = "domain.name";
+
+            // Assert
+            Assert.Equal("https://example.com/logout", logoutConfig.RedirectUrl);
+            Assert.Equal("testToken", logoutConfig.RefreshToken);
+            Assert.Equal("testState", logoutConfig.State);
+            Assert.Equal("custom.domain", logoutConfig.TenantCustomDomain);
+            Assert.Equal("domain.name", logoutConfig.TenantDomainName);
         }
     }
 }

--- a/tests/types-and-dtos/public/WristbandAuthConfigTests.cs
+++ b/tests/types-and-dtos/public/WristbandAuthConfigTests.cs
@@ -1,177 +1,214 @@
-namespace Wristband.AspNet.Auth.Tests
+namespace Wristband.AspNet.Auth.Tests;
+
+public class WristbandAuthConfigTests
 {
-    public class WristbandAuthConfigTests
+    [Fact]
+    public void DefaultConstructor_ShouldInitializePropertiesWithDefaults()
     {
-        [Fact]
-        public void DefaultConstructor_ShouldInitializePropertiesWithDefaults()
-        {
-            var config = new WristbandAuthConfig();
+        var config = new WristbandAuthConfig();
 
-            Assert.Null(config.ClientId);
-            Assert.Null(config.ClientSecret);
-            Assert.Null(config.LoginStateSecret);
-            Assert.Null(config.LoginUrl);
-            Assert.Null(config.RedirectUri);
-            Assert.Null(config.WristbandApplicationVanityDomain);
-            Assert.Null(config.CustomApplicationLoginPageUrl);
-            Assert.Null(config.ParseTenantFromRootDomain);
-            Assert.NotNull(config.Scopes);
-            Assert.Empty(config.Scopes);
-            Assert.False(config.DangerouslyDisableSecureCookies);
-            Assert.False(config.IsApplicationCustomDomainActive);
-            Assert.Equal(60, config.TokenExpirationBuffer);
-        }
+        Assert.True(config.AutoConfigureEnabled);
+        Assert.Null(config.ClientId);
+        Assert.Null(config.ClientSecret);
+        Assert.Null(config.LoginStateSecret);
+        Assert.Null(config.LoginUrl);
+        Assert.Null(config.RedirectUri);
+        Assert.Null(config.WristbandApplicationVanityDomain);
+        Assert.Null(config.CustomApplicationLoginPageUrl);
+        Assert.Null(config.ParseTenantFromRootDomain);
+        Assert.NotNull(config.Scopes);
+        Assert.Empty(config.Scopes);
+        Assert.False(config.DangerouslyDisableSecureCookies);
+        Assert.Null(config.IsApplicationCustomDomainActive);
+        Assert.Equal(60, config.TokenExpirationBuffer);
+    }
 
-        [Fact]
-        public void Constructor_WithValidValues_ShouldSetProperties()
-        {
-            var clientId = "test-client-id";
-            var clientSecret = "test-client-secret";
-            var loginStateSecret = "test-login-state-secret";
-            var loginUrl = "https://login.example.com";
-            var redirectUri = "https://app.example.com/callback";
-            var wristbandApplicationDomain = "wristband.example.com";
-            var customApplicationLoginPageUrl = "https://custom-login.example.com";
-            var dangerouslyDisableSecureCookies = true;
-            var rootDomain = "example.com";
-            var scopes = new List<string> { "openid", "profile", "email" };
-            var isApplicationCustomDomainActive = true;
-            var tokenExpirationBuffer = 120;
+    [Fact]
+    public void Constructor_WithValidValues_ShouldSetProperties()
+    {
+        var autoConfigureEnabled = false;
+        var clientId = "test-client-id";
+        var clientSecret = "test-client-secret";
+        var loginStateSecret = "test-login-state-secret";
+        var loginUrl = "https://login.example.com";
+        var redirectUri = "https://app.example.com/callback";
+        var wristbandApplicationDomain = "wristband.example.com";
+        var customApplicationLoginPageUrl = "https://custom-login.example.com";
+        var dangerouslyDisableSecureCookies = true;
+        var rootDomain = "example.com";
+        var scopes = new List<string> { "openid", "profile", "email" };
+        var isApplicationCustomDomainActive = true;
+        var tokenExpirationBuffer = 120;
 
-            var config = new WristbandAuthConfig(
-                clientId,
-                clientSecret,
-                loginStateSecret,
-                loginUrl,
-                redirectUri,
-                wristbandApplicationDomain,
-                customApplicationLoginPageUrl,
-                dangerouslyDisableSecureCookies,
-                rootDomain,
-                scopes,
-                isApplicationCustomDomainActive,
-                tokenExpirationBuffer
-            );
+        var config = new WristbandAuthConfig(
+            clientId,
+            clientSecret,
+            loginStateSecret,
+            loginUrl,
+            redirectUri,
+            wristbandApplicationDomain,
+            customApplicationLoginPageUrl,
+            dangerouslyDisableSecureCookies,
+            rootDomain,
+            scopes,
+            isApplicationCustomDomainActive,
+            tokenExpirationBuffer,
+            autoConfigureEnabled
+        );
 
-            Assert.Equal(clientId, config.ClientId);
-            Assert.Equal(clientSecret, config.ClientSecret);
-            Assert.Equal(loginStateSecret, config.LoginStateSecret);
-            Assert.Equal(loginUrl, config.LoginUrl);
-            Assert.Equal(redirectUri, config.RedirectUri);
-            Assert.Equal(wristbandApplicationDomain, config.WristbandApplicationVanityDomain);
-            Assert.Equal(customApplicationLoginPageUrl, config.CustomApplicationLoginPageUrl);
-            Assert.Equal(rootDomain, config.ParseTenantFromRootDomain);
-            Assert.NotNull(config.Scopes);
-            Assert.Equal(scopes, config.Scopes);
-            Assert.True(config.DangerouslyDisableSecureCookies);
-            Assert.True(config.IsApplicationCustomDomainActive);
-            Assert.Equal(tokenExpirationBuffer, config.TokenExpirationBuffer);
-        }
+        Assert.False(config.AutoConfigureEnabled);
+        Assert.Equal(clientId, config.ClientId);
+        Assert.Equal(clientSecret, config.ClientSecret);
+        Assert.Equal(loginStateSecret, config.LoginStateSecret);
+        Assert.Equal(loginUrl, config.LoginUrl);
+        Assert.Equal(redirectUri, config.RedirectUri);
+        Assert.Equal(wristbandApplicationDomain, config.WristbandApplicationVanityDomain);
+        Assert.Equal(customApplicationLoginPageUrl, config.CustomApplicationLoginPageUrl);
+        Assert.Equal(rootDomain, config.ParseTenantFromRootDomain);
+        Assert.NotNull(config.Scopes);
+        Assert.Equal(scopes, config.Scopes);
+        Assert.True(config.DangerouslyDisableSecureCookies);
+        Assert.True(config.IsApplicationCustomDomainActive);
+        Assert.Equal(tokenExpirationBuffer, config.TokenExpirationBuffer);
+    }
 
-        [Fact]
-        public void Constructor_WithNullValues_ShouldSetPropertiesToNullOrDefaults()
-        {
-            var config = new WristbandAuthConfig(null, null, null, null, null, null, null, null, null, null, null, null);
+    [Fact]
+    public void Constructor_WithNullValues_ShouldSetPropertiesToNullOrDefaults()
+    {
+        var config = new WristbandAuthConfig(null, null, null, null, null, null, null, null, null, null, null, null, null);
 
-            Assert.Null(config.ClientId);
-            Assert.Null(config.ClientSecret);
-            Assert.Null(config.LoginStateSecret);
-            Assert.Null(config.LoginUrl);
-            Assert.Null(config.RedirectUri);
-            Assert.Null(config.WristbandApplicationVanityDomain);
-            Assert.Null(config.CustomApplicationLoginPageUrl);
-            Assert.Null(config.ParseTenantFromRootDomain);
-            Assert.Null(config.Scopes);
-            Assert.Null(config.DangerouslyDisableSecureCookies);
-            Assert.Null(config.IsApplicationCustomDomainActive);
-            Assert.Null(config.TokenExpirationBuffer);
-        }
+        Assert.Null(config.AutoConfigureEnabled);
+        Assert.Null(config.ClientId);
+        Assert.Null(config.ClientSecret);
+        Assert.Null(config.LoginStateSecret);
+        Assert.Null(config.LoginUrl);
+        Assert.Null(config.RedirectUri);
+        Assert.Null(config.WristbandApplicationVanityDomain);
+        Assert.Null(config.CustomApplicationLoginPageUrl);
+        Assert.Null(config.ParseTenantFromRootDomain);
+        Assert.Null(config.Scopes);
+        Assert.Null(config.DangerouslyDisableSecureCookies);
+        Assert.Null(config.IsApplicationCustomDomainActive);
+        Assert.Null(config.TokenExpirationBuffer);
+    }
 
-        [Fact]
-        public void Properties_ShouldBeSettableAfterConstruction()
-        {
-            var config = new WristbandAuthConfig();
+    [Fact]
+    public void Properties_ShouldBeSettableAfterConstruction()
+    {
+        var config = new WristbandAuthConfig();
 
-            config.ClientId = "updated-client-id";
-            config.ClientSecret = "updated-client-secret";
-            config.LoginStateSecret = "updated-login-state-secret";
-            config.LoginUrl = "https://updated-login.example.com";
-            config.RedirectUri = "https://updated.example.com/callback";
-            config.WristbandApplicationVanityDomain = "updated-wristband.example.com";
-            config.CustomApplicationLoginPageUrl = "https://updated-custom-login.example.com";
-            config.DangerouslyDisableSecureCookies = true;
-            config.ParseTenantFromRootDomain = "updated-example.com";
-            config.Scopes = new List<string> { "custom-scope" };
-            config.IsApplicationCustomDomainActive = true;
-            config.TokenExpirationBuffer = 90;
+        config.AutoConfigureEnabled = false;
+        config.ClientId = "updated-client-id";
+        config.ClientSecret = "updated-client-secret";
+        config.LoginStateSecret = "updated-login-state-secret";
+        config.LoginUrl = "https://updated-login.example.com";
+        config.RedirectUri = "https://updated.example.com/callback";
+        config.WristbandApplicationVanityDomain = "updated-wristband.example.com";
+        config.CustomApplicationLoginPageUrl = "https://updated-custom-login.example.com";
+        config.DangerouslyDisableSecureCookies = true;
+        config.ParseTenantFromRootDomain = "updated-example.com";
+        config.Scopes = new List<string> { "custom-scope" };
+        config.IsApplicationCustomDomainActive = true;
+        config.TokenExpirationBuffer = 90;
 
-            Assert.Equal("updated-client-id", config.ClientId);
-            Assert.Equal("updated-client-secret", config.ClientSecret);
-            Assert.Equal("updated-login-state-secret", config.LoginStateSecret);
-            Assert.Equal("https://updated-login.example.com", config.LoginUrl);
-            Assert.Equal("https://updated.example.com/callback", config.RedirectUri);
-            Assert.Equal("updated-wristband.example.com", config.WristbandApplicationVanityDomain);
-            Assert.Equal("https://updated-custom-login.example.com", config.CustomApplicationLoginPageUrl);
-            Assert.Equal("updated-example.com", config.ParseTenantFromRootDomain);
-            Assert.NotNull(config.Scopes);
-            Assert.Single(config.Scopes);
-            Assert.Equal("custom-scope", config.Scopes[0]);
-            Assert.True(config.DangerouslyDisableSecureCookies);
-            Assert.True(config.IsApplicationCustomDomainActive);
-            Assert.Equal(90, config.TokenExpirationBuffer);
-        }
+        Assert.False(config.AutoConfigureEnabled);
+        Assert.Equal("updated-client-id", config.ClientId);
+        Assert.Equal("updated-client-secret", config.ClientSecret);
+        Assert.Equal("updated-login-state-secret", config.LoginStateSecret);
+        Assert.Equal("https://updated-login.example.com", config.LoginUrl);
+        Assert.Equal("https://updated.example.com/callback", config.RedirectUri);
+        Assert.Equal("updated-wristband.example.com", config.WristbandApplicationVanityDomain);
+        Assert.Equal("https://updated-custom-login.example.com", config.CustomApplicationLoginPageUrl);
+        Assert.Equal("updated-example.com", config.ParseTenantFromRootDomain);
+        Assert.NotNull(config.Scopes);
+        Assert.Single(config.Scopes);
+        Assert.Equal("custom-scope", config.Scopes[0]);
+        Assert.True(config.DangerouslyDisableSecureCookies);
+        Assert.True(config.IsApplicationCustomDomainActive);
+        Assert.Equal(90, config.TokenExpirationBuffer);
+    }
 
-        [Fact]
-        public void Constructor_WithSpecificTokenExpirationBuffer_ShouldSetValue()
-        {
-            var tokenExpirationBuffer = 300;
+    [Fact]
+    public void Constructor_WithSpecificTokenExpirationBuffer_ShouldSetValue()
+    {
+        var tokenExpirationBuffer = 300;
 
-            var config = new WristbandAuthConfig(
-                clientId: null,
-                clientSecret: null,
-                loginStateSecret: null,
-                loginUrl: null,
-                redirectUri: null,
-                wristbandApplicationVanityDomain: null,
-                customApplicationLoginPageUrl: null,
-                dangerouslyDisableSecureCookies: null,
-                parseTenantFromRootDomain: null,
-                scopes: null,
-                isApplicationCustomDomainActive: null,
-                tokenExpirationBuffer: tokenExpirationBuffer
-            );
+        var config = new WristbandAuthConfig(
+            clientId: null,
+            clientSecret: null,
+            loginStateSecret: null,
+            loginUrl: null,
+            redirectUri: null,
+            wristbandApplicationVanityDomain: null,
+            customApplicationLoginPageUrl: null,
+            dangerouslyDisableSecureCookies: null,
+            parseTenantFromRootDomain: null,
+            scopes: null,
+            isApplicationCustomDomainActive: null,
+            tokenExpirationBuffer: tokenExpirationBuffer
+        );
 
-            Assert.Equal(tokenExpirationBuffer, config.TokenExpirationBuffer);
-        }
+        Assert.Equal(tokenExpirationBuffer, config.TokenExpirationBuffer);
+    }
 
-        [Fact]
-        public void Constructor_WithZeroTokenExpirationBuffer_ShouldSetValue()
-        {
-            var config = new WristbandAuthConfig(
-                clientId: null,
-                clientSecret: null,
-                loginStateSecret: null,
-                loginUrl: null,
-                redirectUri: null,
-                wristbandApplicationVanityDomain: null,
-                customApplicationLoginPageUrl: null,
-                dangerouslyDisableSecureCookies: null,
-                parseTenantFromRootDomain: null,
-                scopes: null,
-                isApplicationCustomDomainActive: null,
-                tokenExpirationBuffer: 0
-            );
+    [Fact]
+    public void Constructor_WithZeroTokenExpirationBuffer_ShouldSetValue()
+    {
+        var config = new WristbandAuthConfig(
+            clientId: null,
+            clientSecret: null,
+            loginStateSecret: null,
+            loginUrl: null,
+            redirectUri: null,
+            wristbandApplicationVanityDomain: null,
+            customApplicationLoginPageUrl: null,
+            dangerouslyDisableSecureCookies: null,
+            parseTenantFromRootDomain: null,
+            scopes: null,
+            isApplicationCustomDomainActive: null,
+            tokenExpirationBuffer: 0
+        );
 
-            Assert.Equal(0, config.TokenExpirationBuffer);
-        }
+        Assert.Equal(0, config.TokenExpirationBuffer);
+    }
 
-        [Fact]
-        public void TokenExpirationBuffer_ShouldHaveDefaultValue60()
-        {
-            // Test that the property has the default value when using parameterless constructor
-            var config = new WristbandAuthConfig();
+    [Fact]
+    public void TokenExpirationBuffer_ShouldHaveDefaultValue60()
+    {
+        // Test that the property has the default value when using parameterless constructor
+        var config = new WristbandAuthConfig();
 
-            Assert.Equal(60, config.TokenExpirationBuffer);
-        }
+        Assert.Equal(60, config.TokenExpirationBuffer);
+    }
+
+    [Fact]
+    public void AutoConfigureEnabled_ShouldHaveDefaultValueTrue()
+    {
+        // Test that the property has the default value when using parameterless constructor
+        var config = new WristbandAuthConfig();
+
+        Assert.True(config.AutoConfigureEnabled);
+    }
+
+    [Fact]
+    public void Constructor_WithAutoConfigureEnabledFalse_ShouldSetValue()
+    {
+        var config = new WristbandAuthConfig(
+            clientId: null,
+            clientSecret: null,
+            loginStateSecret: null,
+            loginUrl: null,
+            redirectUri: null,
+            wristbandApplicationVanityDomain: null,
+            customApplicationLoginPageUrl: null,
+            dangerouslyDisableSecureCookies: null,
+            parseTenantFromRootDomain: null,
+            scopes: null,
+            isApplicationCustomDomainActive: null,
+            tokenExpirationBuffer: null,
+            autoConfigureEnabled: false
+        );
+
+        Assert.False(config.AutoConfigureEnabled);
     }
 }

--- a/tests/wristband-auth-service/CallbackTests.cs
+++ b/tests/wristband-auth-service/CallbackTests.cs
@@ -23,7 +23,8 @@ public class CallbackTests
             LoginStateSecret = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)),
             LoginUrl = "https://login.example.com",
             RedirectUri = "https://app.example.com/callback",
-            WristbandApplicationVanityDomain = "wristband.example.com"
+            WristbandApplicationVanityDomain = "wristband.example.com",
+            AutoConfigureEnabled = false,
         };
 
         _mockLoginStateHandler = new Mock<ILoginStateHandler>();
@@ -34,13 +35,13 @@ public class CallbackTests
     {
         var wristbandAuthService = new WristbandAuthService(authConfig);
 
-        var fieldInfo = typeof(WristbandAuthService).GetField("mWristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        var fieldInfo = typeof(WristbandAuthService).GetField("_wristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
         if (fieldInfo != null)
         {
             fieldInfo.SetValue(wristbandAuthService, _mockApiClient.Object);
         }
 
-        var loginHandlerField = typeof(WristbandAuthService).GetField("mLoginStateHandler", BindingFlags.NonPublic | BindingFlags.Instance);
+        var loginHandlerField = typeof(WristbandAuthService).GetField("_loginStateHandler", BindingFlags.NonPublic | BindingFlags.Instance);
         if (loginHandlerField != null)
         {
             loginHandlerField.SetValue(wristbandAuthService, _mockLoginStateHandler.Object);
@@ -218,7 +219,8 @@ public class CallbackTests
             LoginUrl = "https://{tenant_domain}.example.com/login",
             RedirectUri = "https://{tenant_domain}.example.com/callback",
             WristbandApplicationVanityDomain = _defaultConfig.WristbandApplicationVanityDomain,
-            ParseTenantFromRootDomain = "example.com"
+            ParseTenantFromRootDomain = "example.com",
+            AutoConfigureEnabled = false,
         };
         var service = SetupWristbandAuthService(config);
         var httpContext = TestUtils.setupHttpContext(

--- a/tests/wristband-auth-service/DiscoverTests.cs
+++ b/tests/wristband-auth-service/DiscoverTests.cs
@@ -1,0 +1,276 @@
+using System.Reflection;
+
+using Moq;
+
+namespace Wristband.AspNet.Auth.Tests;
+
+public class DiscoverTests
+{
+    private readonly Mock<IWristbandApiClient> _mockApiClient = new Mock<IWristbandApiClient>();
+
+    [Fact]
+    public async Task Discover_Should_ThrowWristbandError_When_AutoConfigureDisabled()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            LoginUrl = "https://example.com/login",
+            RedirectUri = "https://example.com/callback",
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = false, // Disabled
+        };
+
+        var service = new WristbandAuthService(authConfig);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => service.Discover()
+        );
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Equal("Cannot preload configs when AutoConfigureEnabled is false. Set AutoConfigureEnabled to true.", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task Discover_Should_CallPreloadConfig_When_AutoConfigureEnabled()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = true, // Enabled
+        };
+
+        // Mock the API client to return a valid SDK configuration
+        _mockApiClient
+            .Setup(m => m.GetSdkConfiguration())
+            .ReturnsAsync(new SdkConfiguration
+            {
+                LoginUrl = "https://example.com/login",
+                RedirectUri = "https://example.com/callback",
+                IsApplicationCustomDomainActive = false,
+                CustomApplicationLoginPageUrl = null,
+                LoginUrlTenantDomainSuffix = null
+            });
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // This should complete without throwing an exception
+        await service.Discover();
+
+        // Verify that the SDK configuration was fetched (indicating PreloadConfig was called)
+        _mockApiClient.Verify(m => m.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Discover_Should_DefaultToTrue_When_AutoConfigureNotSpecified()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            // AutoConfigureEnabled not specified, should default to true
+        };
+
+        // Mock the API client to return a valid SDK configuration
+        _mockApiClient
+            .Setup(m => m.GetSdkConfiguration())
+            .ReturnsAsync(new SdkConfiguration
+            {
+                LoginUrl = "https://example.com/login",
+                RedirectUri = "https://example.com/callback",
+                IsApplicationCustomDomainActive = false,
+                CustomApplicationLoginPageUrl = null,
+                LoginUrlTenantDomainSuffix = null
+            });
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // This should complete without throwing an exception since AutoConfigureEnabled defaults to true
+        await service.Discover();
+
+        // Verify that the SDK configuration was fetched
+        _mockApiClient.Verify(m => m.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Discover_Should_PropagateConfigResolverExceptions()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = true,
+        };
+
+        // Mock the API client to throw an exception during SDK config fetch
+        var expectedError = new WristbandError("config_fetch_error", "Failed to fetch configuration");
+        _mockApiClient
+            .Setup(m => m.GetSdkConfiguration())
+            .ThrowsAsync(expectedError);
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // The exception from ConfigResolver.PreloadConfig should be propagated
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => service.Discover()
+        );
+
+        // Should be the original error wrapped by ConfigResolver logic
+        Assert.Contains("Failed to fetch SDK configuration", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task Discover_Should_HandleNetworkErrors()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = true,
+        };
+
+        // Mock the API client to throw a network-related exception
+        _mockApiClient
+            .Setup(m => m.GetSdkConfiguration())
+            .ThrowsAsync(new HttpRequestException("Network error"));
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // Should propagate as a WristbandError due to ConfigResolver's error handling
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => service.Discover()
+        );
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("Failed to fetch SDK configuration", exception.ErrorDescription);
+        Assert.Contains("Network error", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task Discover_Should_CacheConfiguration_OnSuccessfulCall()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = true,
+        };
+
+        // Mock the API client to return a valid SDK configuration
+        _mockApiClient
+            .Setup(m => m.GetSdkConfiguration())
+            .ReturnsAsync(new SdkConfiguration
+            {
+                LoginUrl = "https://example.com/login",
+                RedirectUri = "https://example.com/callback",
+                IsApplicationCustomDomainActive = false,
+                CustomApplicationLoginPageUrl = null,
+                LoginUrlTenantDomainSuffix = null
+            });
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // Call Discover twice
+        await service.Discover();
+        await service.Discover();
+
+        // Verify that the SDK configuration was only fetched once (due to caching)
+        _mockApiClient.Verify(m => m.GetSdkConfiguration(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Discover_Should_HandleInvalidSdkConfigurationResponse()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = true,
+        };
+
+        // Mock the API client to return an invalid SDK configuration (missing required fields)
+        _mockApiClient
+            .Setup(m => m.GetSdkConfiguration())
+            .ReturnsAsync(new SdkConfiguration
+            {
+                IsApplicationCustomDomainActive = false,
+                CustomApplicationLoginPageUrl = null,
+                LoginUrlTenantDomainSuffix = null
+            });
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // Should throw a validation error
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => service.Discover()
+        );
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("missing required field", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task Discover_Should_HandleMultipleFailuresWithRetry()
+    {
+        var authConfig = new WristbandAuthConfig
+        {
+            ClientId = "valid-client-id",
+            ClientSecret = "valid-client-secret",
+            LoginStateSecret = new string('a', 32),
+            WristbandApplicationVanityDomain = "example.com",
+            AutoConfigureEnabled = true,
+        };
+
+        // Mock the API client to fail twice, then succeed
+        _mockApiClient
+            .SetupSequence(m => m.GetSdkConfiguration())
+            .ThrowsAsync(new HttpRequestException("Temporary failure"))
+            .ThrowsAsync(new HttpRequestException("Another failure"))
+            .ReturnsAsync(new SdkConfiguration
+            {
+                LoginUrl = "https://example.com/login",
+                RedirectUri = "https://example.com/callback",
+                IsApplicationCustomDomainActive = false,
+                CustomApplicationLoginPageUrl = null,
+                LoginUrlTenantDomainSuffix = null
+            });
+
+        var service = CreateServiceWithMockedApiClient(authConfig);
+
+        // Should succeed after retries
+        await service.Discover();
+
+        // Verify that multiple attempts were made
+        _mockApiClient.Verify(m => m.GetSdkConfiguration(), Times.Exactly(3));
+    }
+
+    private WristbandAuthService CreateServiceWithMockedApiClient(WristbandAuthConfig authConfig)
+    {
+        var service = new WristbandAuthService(authConfig);
+
+        // Inject the mock API client into the service
+        var apiClientField = typeof(WristbandAuthService).GetField("_wristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        apiClientField!.SetValue(service, _mockApiClient.Object);
+
+        // Create a new ConfigResolver with the mocked API client and inject it
+        var mockConfigResolver = new ConfigResolver(authConfig, _mockApiClient.Object);
+        var configResolverField = typeof(WristbandAuthService).GetField("_configResolver", BindingFlags.NonPublic | BindingFlags.Instance);
+        configResolverField!.SetValue(service, mockConfigResolver);
+
+        return service;
+    }
+}

--- a/tests/wristband-auth-service/RefreshTokenIfExpiredTests.cs
+++ b/tests/wristband-auth-service/RefreshTokenIfExpiredTests.cs
@@ -23,12 +23,13 @@ public class RefreshTokenIfExpiredTests
             RedirectUri = "https://example.com/callback",
             WristbandApplicationVanityDomain = "example.com",
             IsApplicationCustomDomainActive = false,
+            AutoConfigureEnabled = false,
         };
 
         _wristbandAuthService = new WristbandAuthService(_authConfig);
 
         // Use reflection to inject the mock API Client object into the service
-        var fieldInfo = typeof(WristbandAuthService).GetField("mWristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        var fieldInfo = typeof(WristbandAuthService).GetField("_wristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
         if (fieldInfo != null && _mockApiClient != null)
         {
             fieldInfo.SetValue(_wristbandAuthService, _mockApiClient.Object);
@@ -192,9 +193,6 @@ public class RefreshTokenIfExpiredTests
 
         Assert.NotNull(exception);
         Assert.Equal("Some error", exception.Message);
-
-        var output = stringWriter.ToString();
-        Assert.Contains("Attempt 3 failed. Aborting...", output);
     }
 
     [Fact]
@@ -253,7 +251,7 @@ public class RefreshTokenIfExpiredTests
         var customService = new WristbandAuthService(customConfig);
 
         // Inject mock API client
-        var fieldInfo = typeof(WristbandAuthService).GetField("mWristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        var fieldInfo = typeof(WristbandAuthService).GetField("_wristbandApiClient", BindingFlags.NonPublic | BindingFlags.Instance);
         fieldInfo?.SetValue(customService, _mockApiClient.Object);
 
         var mockTokenResponse = new TokenResponse


### PR DESCRIPTION
**Breaking Change (v3.x Migration Guide included):**

- The deprecated `AddWristbandAuth()` method that accepted `IConfiguration` and `configSectionName` parameters has been removed in version 3.x. You must now use the direct configuration approach.

**Backwards-Compatible Changes**

- The all new SDK auto-configuration functionality is now available. It supports both lazy and eager auto-configuration. Auto-configuration is enabled by default and will fetch missing configuration values from the Wristband SDK Configuration Endpoint when any auth method is first called. Manual configuration values take precedence over auto-configured values. Set `AutoConfigureEnabled` to `false` in the `WristbandAuthConfig` to disable.

- The new async `Discover()` method in `WristbandAuthService` can be used to eager-load SDK configurations from the Wristband SDK Configuration Endpoint on server startup.

- The `LoginStateSecret` config is no longer required. If not provided, it will default to using the client secret. For enhanced security, it is recommended to provide a value that is unique from the client secret. You can run `openssl rand -base64 32` to create a secret from your CLI.

- The `LoginConfig` class for the `Login()` method now supports a `ReturnUrl` field. If a value is provided, then it takes precedence over the `return_url` request query parameter.

- The `LogoutConfig` class for the `Logout()` method now supports a `State` field. This is an optional value that allows you to preserve application state through the logout flow. If provided, it will be appended as a query parameter to the resolved logout URL. Maximum length of 512 characters. This is useful for tracking logout context, displaying post-logout messages, or handling different logout scenarios.