### PR TITLE
Release 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You should see the dependency added to your `.csproj` file:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Wristband.AspNet.Auth" Version="4.1.0" />
+  <PackageReference Include="Wristband.AspNet.Auth" Version="4.2.0" />
 </ItemGroup>
 ```
 
@@ -1072,6 +1072,22 @@ GET https://customer01.yourapp.io/auth/login?login_hint=user@wristband.dev
 ```
 
 If the request to your Login Endpoint passes this parameter, it will be appended as part of the redirect request to the Wristband Authorize Endpoint. Typically, the email form field on the Tenant-Level Login page is pre-filled when a user has previously entered their email on the Application-Level Login Page.
+
+#### IDP Hints
+
+If you want to bypass the Wristband-hosted Tenant Login Page entirely and send users directly to a specific identity provider's login page, you can pass the `idp_hint` query parameter to your Login Endpoint:
+
+```sh
+GET https://customer01.yourapp.io/auth/login?idp_hint=google
+```
+
+The value should be the `name` field of an identity provider that is currently enabled for the tenant. When Wristband receives this hint, it checks if the provided IdP name matches an enabled identity provider for that tenant:
+
+- **Matching external IdP (e.g. `google`)** — Wristband skips the Tenant Login Page entirely and redirects the user straight to that external IdP's login page (e.g. Google's login page).
+- **Wristband IdP name** — Wristband displays the Tenant Login Page but shows only the Wristband email-based login form, hiding any external IdP buttons.
+- **Unrecognized or invalid value** — Wristband ignores the hint and displays the Tenant Login Page as normal.
+
+This is useful when your application already knows which identity provider a user should authenticate with, allowing you to skip the IdP selection step entirely and provide a more seamless login experience.
 
 #### Return URLs
 

--- a/src/ConfigResolver.cs
+++ b/src/ConfigResolver.cs
@@ -243,7 +243,7 @@ internal class ConfigResolver
         if (GetAutoConfigureEnabled())
         {
             var sdkConfig = await LoadSdkConfig();
-            return sdkConfig.RedirectUri;
+            return sdkConfig.RedirectUri ?? string.Empty;
         }
 
         // 3. This should not happen if validation is done properly
@@ -425,22 +425,24 @@ internal class ConfigResolver
 
     private void ValidateAllDynamicConfigs(SdkConfiguration sdkConfiguration)
     {
-        // Validate that required fields are present in the SDK config response
-        if (string.IsNullOrEmpty(sdkConfiguration.LoginUrl))
-        {
-            throw new WristbandError("sdk_config_error", "SDK configuration response missing required field: LoginUrl");
-        }
-
-        if (string.IsNullOrEmpty(sdkConfiguration.RedirectUri))
-        {
-            throw new WristbandError("sdk_config_error", "SDK configuration response missing required field: RedirectUri");
-        }
-
         // Use manual config values if provided, otherwise use SDK config values
         var loginUrl = _authConfig.LoginUrl ?? sdkConfiguration.LoginUrl;
         var redirectUri = _authConfig.RedirectUri ?? sdkConfiguration.RedirectUri;
         var parseTenantFromRootDomain = _authConfig.ParseTenantFromRootDomain ??
             sdkConfiguration.LoginUrlTenantDomainSuffix;
+
+        // Validate that required fields are present in the SDK config response
+        if (string.IsNullOrEmpty(loginUrl))
+        {
+            throw new WristbandError("sdk_config_error", "SDK configuration response missing required field: LoginUrl");
+        }
+
+        if (string.IsNullOrEmpty(redirectUri))
+        {
+            throw new WristbandError(
+                "sdk_config_error",
+                "The [RedirectUri] could not be resolved. Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.");
+        }
 
         var hasRootDomain = !string.IsNullOrEmpty(parseTenantFromRootDomain);
         var loginUrlHasToken = ContainsTenantPlaceholder(loginUrl);

--- a/src/Types/internal/SdkConfiguration.cs
+++ b/src/Types/internal/SdkConfiguration.cs
@@ -49,7 +49,9 @@ internal class SdkConfiguration
     /// Gets or sets the URI that Wristband will redirect to after authenticating a user.
     /// This should point to your application's callback endpoint.
     /// If using tenant subdomains, this value must contain the `{tenant_name}` placeholder.
+    /// When null, the redirect URI must be provided explicitly in the SDK configuration,
+    /// which is required when the OAuth2 client has multiple redirect URIs registered.
     /// </summary>
     [JsonPropertyName("redirectUri")]
-    public string RedirectUri { get; set; } = string.Empty;
+    public string? RedirectUri { get; set; }
 }

--- a/src/Wristband.AspNet.Auth.csproj
+++ b/src/Wristband.AspNet.Auth.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/WristbandAuthService.cs
+++ b/src/WristbandAuthService.cs
@@ -129,8 +129,33 @@ public class WristbandAuthService : IWristbandAuthService
             { "code_challenge", CreateCodeChallenge(loginState.CodeVerifier) },
             { "code_challenge_method", "S256" },
             { "nonce", _loginStateHandler.GenerateRandomString(32) },
-            { "login_hint", context.Request.Query["login_hint"].FirstOrDefault() ?? string.Empty },
         };
+
+        // Optionally add login_hint query parameter if it was included in the login request.
+        var loginHintValues = context.Request.Query["login_hint"];
+        if (loginHintValues.Count > 1)
+        {
+            throw new ArgumentException("More than one [login_hint] query parameter was encountered");
+        }
+
+        var loginHint = loginHintValues.FirstOrDefault();
+        if (!string.IsNullOrEmpty(loginHint))
+        {
+            queryParams["login_hint"] = loginHint;
+        }
+
+        // Optionally add idp_hint query parameter if it was included in the login request.
+        var idpHintValues = context.Request.Query["idp_hint"];
+        if (idpHintValues.Count > 1)
+        {
+            throw new ArgumentException("More than one [idp_hint] query parameter was encountered");
+        }
+
+        var idpHint = idpHintValues.FirstOrDefault();
+        if (!string.IsNullOrEmpty(idpHint))
+        {
+            queryParams["idp_hint"] = idpHint;
+        }
 
         var separator = isApplicationCustomDomainActive ? '.' : '-';
         var queryString = string.Join("&", queryParams

--- a/tests/ConfigResolverTests.cs
+++ b/tests/ConfigResolverTests.cs
@@ -930,7 +930,72 @@ public class ConfigResolverTests
             () => resolver.GetRedirectUri());
 
         Assert.Equal("sdk_config_error", exception.Error);
-        Assert.Contains("SDK configuration response missing required field: RedirectUri", exception.ErrorDescription);
+        Assert.Contains("The [RedirectUri] could not be resolved. Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task GetRedirectUri_WithNullSdkRedirectUriAndManualOverride_ReturnsManualValue()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = null // SDK returns null (multiple redirect URIs registered)
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var config = new WristbandAuthConfig
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            WristbandApplicationVanityDomain = "test.wristband.dev",
+            RedirectUri = "https://manual-callback.example.com",
+            AutoConfigureEnabled = true
+        };
+        var resolver = new ConfigResolver(config, _mockApiClient.Object);
+
+        var result = await resolver.GetRedirectUri();
+
+        Assert.Equal("https://manual-callback.example.com", result);
+        _mockApiClient.Verify(x => x.GetSdkConfiguration(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetRedirectUri_WithEmptySdkRedirectUri_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = "" // Empty string also triggers error
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetRedirectUri());
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("The [RedirectUri] could not be resolved", exception.ErrorDescription);
+        Assert.Contains("Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.", exception.ErrorDescription);
+    }
+
+    [Fact]
+    public async Task GetRedirectUri_WithNullSdkRedirectUri_ThrowsWristbandError()
+    {
+        var sdkConfig = new SdkConfiguration
+        {
+            LoginUrl = "https://login.example.com",
+            RedirectUri = null // SDK returns null (multiple redirect URIs registered)
+        };
+        _mockApiClient.Setup(x => x.GetSdkConfiguration()).ReturnsAsync(sdkConfig);
+
+        var resolver = new ConfigResolver(_validConfig, _mockApiClient.Object);
+
+        var exception = await Assert.ThrowsAsync<WristbandError>(
+            () => resolver.GetRedirectUri());
+
+        Assert.Equal("sdk_config_error", exception.Error);
+        Assert.Contains("The [RedirectUri] could not be resolved. Provide it explicitly in your SDK config or ensure your Wristband OAuth2 Client has a single redirect URI configured.", exception.ErrorDescription);
     }
 
     // ////////////////////////////////////

--- a/tests/types-and-dtos/internal/SdkConfigurationTests.cs
+++ b/tests/types-and-dtos/internal/SdkConfigurationTests.cs
@@ -13,7 +13,7 @@ public class SdkConfigurationTests
         Assert.False(config.IsApplicationCustomDomainActive);
         Assert.Equal(string.Empty, config.LoginUrl);
         Assert.Null(config.LoginUrlTenantDomainSuffix);
-        Assert.Equal(string.Empty, config.RedirectUri);
+        Assert.Null(config.RedirectUri);
     }
 
     [Fact]
@@ -118,11 +118,11 @@ public class SdkConfigurationTests
     }
 
     [Fact]
-    public void RedirectUri_ShouldDefaultToEmptyString()
+    public void RedirectUri_ShouldDefaultToNull()
     {
         var config = new SdkConfiguration();
 
-        Assert.Equal(string.Empty, config.RedirectUri);
+        Assert.Null(config.RedirectUri);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class SdkConfigurationTests
             ""isApplicationCustomDomainActive"": false,
             ""loginUrl"": """",
             ""loginUrlTenantDomainSuffix"": null,
-            ""redirectUri"": """"
+            ""redirectUri"": null
         }";
 
         var config = JsonSerializer.Deserialize<SdkConfiguration>(json);
@@ -196,7 +196,7 @@ public class SdkConfigurationTests
         Assert.False(config.IsApplicationCustomDomainActive);
         Assert.Equal(string.Empty, config.LoginUrl);
         Assert.Null(config.LoginUrlTenantDomainSuffix);
-        Assert.Equal(string.Empty, config.RedirectUri);
+        Assert.Null(config.RedirectUri);
     }
 
     ////////////////////////////////////////////////////////

--- a/tests/wristband-auth-service/LoginTests.cs
+++ b/tests/wristband-auth-service/LoginTests.cs
@@ -226,6 +226,58 @@ public class LoginTests
     }
 
     [Fact]
+    public async Task Login_WithIdpHint_IncludesInAuthorizationUrl()
+    {
+        var service = SetupWristbandAuthService(_defaultConfig);
+        var idpHint = "google";
+        var httpContext = TestUtils.setupHttpContext(
+            "app.example.com",
+            $"tenant_name=tenant1&idp_hint={Uri.EscapeDataString(idpHint)}");
+
+        var result = await service.Login(httpContext, null);
+
+        Assert.Contains($"idp_hint={Uri.EscapeDataString(idpHint)}", result);
+    }
+
+    [Fact]
+    public async Task Login_WithMultipleLoginHintParams_ThrowsArgumentException()
+    {
+        var service = SetupWristbandAuthService(_defaultConfig);
+        var httpContext = TestUtils.setupHttpContext(
+            "app.example.com",
+            "tenant_name=tenant1&login_hint=user1@example.com&login_hint=user2@example.com");
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.Login(httpContext, null));
+
+        Assert.Contains("More than one [login_hint] query parameter was encountered", ex.Message);
+    }
+
+    [Fact]
+    public async Task Login_WithMultipleIdpHintParams_ThrowsArgumentException()
+    {
+        var service = SetupWristbandAuthService(_defaultConfig);
+        var httpContext = TestUtils.setupHttpContext(
+            "app.example.com",
+            "tenant_name=tenant1&idp_hint=google&idp_hint=github");
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.Login(httpContext, null));
+
+        Assert.Contains("More than one [idp_hint] query parameter was encountered", ex.Message);
+    }
+
+    [Fact]
+    public async Task Login_WithoutLoginHintAndIdpHint_ExcludesFromAuthorizationUrl()
+    {
+        var service = SetupWristbandAuthService(_defaultConfig);
+        var httpContext = TestUtils.setupHttpContext("app.example.com", "tenant_name=tenant1");
+
+        var result = await service.Login(httpContext, null);
+
+        Assert.DoesNotContain("login_hint", result);
+        Assert.DoesNotContain("idp_hint", result);
+    }
+
+    [Fact]
     public async Task Login_WithAdditionalScopes_IncludesAllScopes()
     {
         var config = new WristbandAuthConfig


### PR DESCRIPTION
# Release 4.2.0

## New Features

### ✨ IDP Hint Support
The `login()` flow now forwards the `idp_hint` query parameter to the Wristband Authorize Endpoint when present. This allows applications to bypass the Wristband-hosted Tenant Login Page and send users directly to a specific identity provider.

**Behavior:**
- Matching external IDP — redirects user straight to that IDP's login page (e.g. Google)
- Wristband IDP name — shows only the Wristband login form, no external IDP buttons
- Unrecognized or invalid value — ignored, login page displays as normal

## Bug Fixes

### 🐛 Fix: Explicit `RedirectUri` no longer fails when OAuth2 client has multiple redirect URIs
Previously, providing `RedirectUri` explicitly in the SDK config would still throw an error during auto-configuration if the Wristband OAuth2 client had multiple redirect URIs configured (causing the endpoint to return `null`). The SDK now correctly uses the manually provided value and skips the null endpoint response.